### PR TITLE
backlink: 收录提交口独立成表，indexed 必须指名引擎

### DIFF
--- a/backlink/CONTRIBUTING.md
+++ b/backlink/CONTRIBUTING.md
@@ -109,8 +109,8 @@ One channel or one correction per PR where practical. It keeps review honest.
 
 ## Data model
 
-Two files, two purposes. Both live in `data/`, both have a JSON Schema in
-`data/schema/`, and both are checked by `scripts/validate-data.mjs`.
+Three files, three purposes. All live in `data/`, all have a JSON Schema in
+`data/schema/`, and all are checked by `scripts/validate-data.mjs`.
 
 ### `data/free-channels.json` — publish at no cost
 
@@ -153,6 +153,27 @@ gets quoted as current long after it stops being true.
 **Recording is not recommending.** This file exists so the decision is
 *informed*. Whether to buy is the site owner's call. Do not relabel a
 `link-package` as a "directory submission" to make it sound acceptable.
+
+### `data/index-submission.json` — hand a URL to an engine, get no link
+
+**Nothing in this file is a backlink.** These are index-submission endpoints:
+you give a search engine a URL and receive a confirmation string. They earn a
+place in a backlink Skill because the verify stage's `indexed` state never said
+*whose* index, and because an engine outside the IndexNow membership receives
+nothing from the usual automated push — so its pages have to be handed over by
+hand.
+
+Do not merge a row of this into `free-channels.json` to make the channel list
+look longer. That file's contract is *a place that publishes a link*, and
+`anchorRendered` / `relObserved` have no meaning here.
+
+| Field | Why it matters |
+| --- | --- |
+| `independentIndex` + `indexNowMember` | Together they are the reason a row exists. An engine already covered by IndexNow, with no crawler of its own, needs no manual submission — the validator rejects that combination outright, because such a record invents work that accomplishes nothing. |
+| `batch` | `false` means the cost of a site-wide submission is linear in page count. Say the number out loud before starting; 38 pages is 38 operations. |
+| `aiGrounding` | The GEO argument, and the field most likely to rot into folklore. Record only what the operator publishes about its own index, with the URL that says it. **Never** record "assistant X uses index Y" — those pairings change quietly and are rarely confirmed by either party. |
+| `traps` | Same role as in `free-channels.json`. Passive human checks are the recurring theme: one form ignores a synthesised `click()` entirely because the check demands a trusted event. Documenting that is not a bypass — the check still runs and clears itself, or the channel is rejected. |
+| `evidence.what` | Say how many submissions were individually re-read. A campaign that confirmed 12 of 38 says 12 of 38; rounding that up to "all confirmed" is the exact failure this project exists to prevent. |
 
 ## Scope and conduct
 

--- a/backlink/SKILL.md
+++ b/backlink/SKILL.md
@@ -38,7 +38,8 @@ backlink/
 ├── data/                 ← THE DATABASE. Machine-readable, PR-able, CI-checked.
 │   ├── free-channels.json     places that publish a link at no cost
 │   ├── paid-platforms.json    platforms observed carrying purchased placements
-│   └── schema/                JSON Schema for both files
+│   ├── index-submission.json  engines that take a URL and publish NO link
+│   └── schema/                JSON Schema for the files above
 │
 ├── scripts/              ← run these; do not re-derive their knowledge by hand
 │   ├── validate-data.mjs           PR gate. CI runs exactly this. Must exit 0.
@@ -56,6 +57,7 @@ backlink/
 └── references/           ← method, traps, and why the rules are the rules
     ├── instant-publish.md     ★ free channels: how each class behaves, what kills them
     ├── paid-platforms.md      ★ paid: tiers, why a burst is not a purchase
+    ├── index-submission.md      index-only channels; why `indexed` must name an engine
     ├── field-notes.md           what actually blocks submissions in practice
     ├── harvest.md               scraping failures that look like success
     ├── safety-policy.md         read before any fill / submit / logged-in action
@@ -76,6 +78,7 @@ backlink/
 | "Find me **new** opportunities" | [discovery-loop.md](references/discovery-loop.md) — and merge whatever you harvest back into the registry |
 | "Is this link profile any good" | [link-quality-rubric.md](references/link-quality-rubric.md) |
 | "Get these numbers out of a dashboard with no API" | [harvest.md](references/harvest.md) |
+| "Submit our pages to **Brave / another engine**" · "why is our index count low on X" | [index-submission.md](references/index-submission.md) — it publishes no link, so it never enters the placement ledger |
 
 Query the data directly rather than reading the JSON by eye:
 
@@ -331,6 +334,12 @@ Never promote a record based on a filled form, a pending notice, or a historical
 assumption. Search Console may provide supplementary link/index evidence, but
 verify the exact live URL and anchor where possible.
 
+**`indexed` must name the engine** — write `indexed@google`, `indexed@brave`.
+An unqualified "indexed" is a claim about the whole web built from one crawler's
+opinion, and every promotion so far has in fact come from Google or Bing. The
+engines with their own crawlers, what reaches them, and what does not, are in
+[index-submission.md](references/index-submission.md).
+
 ## Non-negotiable rules
 
 - No coordinate-based “human-like” clicking.
@@ -338,7 +347,9 @@ verify the exact live URL and anchor where possible.
 - No generic praise, fake identity, invented metrics, or irrelevant comments.
 - No link farms, spam generators, adult/malware surfaces, hidden reciprocal
   links, temporary eligibility pages, or cloaking.
-- Do not record a submission as a backlink.
+- Do not record a submission as a backlink. This includes handing a URL to a
+  search engine: that is an index-submission channel, it publishes no link, and
+  it belongs in `data/index-submission.json` rather than the placement ledger.
 - Do not record `follow`, `nofollow`, `ugc`, `sponsored`, or `indexed` without
   observing it for the exact URL.
 - Do not automatically resubmit an unconfirmed target.
@@ -381,6 +392,17 @@ assertion about a platform, never an observation of a link, and the sweep that
 produced that section found a listed site that publishes your URL as plain text
 with no anchor at all, plus one whose domain now redirects to an unrelated product
 while still answering 200.
+
+When the ask is about **getting pages into an index** rather than getting a link
+— submitting URLs to an engine, a low `site:` count somewhere that is not Google,
+or optimising for AI answers — read
+[index-submission.md](references/index-submission.md). It carries the reason a
+second index matters (an independent index is a grounding source for AI answers,
+so a page missing from it is missing from every answer built on it), the rule
+that keeps these channels out of `free-channels.json`, the baseline-then-recheck
+measurement that makes such a campaign judgeable, and the per-engine traps —
+including a form where a synthesised `click()` silently does nothing because the
+passive check demands a trusted event.
 
 When the ask is "somewhere I can post without registering", read
 [instant-publish.md](references/instant-publish.md) **first**. Directory

--- a/backlink/SKILL.md
+++ b/backlink/SKILL.md
@@ -372,6 +372,16 @@ Merge every new competitor harvest into it — the registry's value comes from
 repetition across independent subjects, so it is only as good as what has been
 fed in.
 
+When someone hands you **a list of places to get backlinks** — a tiered table with
+a Dofollow column, a competitor's "we got 200 links here" post, or another Skill's
+directory list — read the "Reading a third-party list" section of
+[instant-publish.md](references/instant-publish.md) before acting on any row of it.
+Those lists are worth harvesting and worthless to trust: the Dofollow column is an
+assertion about a platform, never an observation of a link, and the sweep that
+produced that section found a listed site that publishes your URL as plain text
+with no anchor at all, plus one whose domain now redirects to an unrelated product
+while still answering 200.
+
 When the ask is "somewhere I can post without registering", read
 [instant-publish.md](references/instant-publish.md) **first**. Directory
 submission does not satisfy that request and burning a campaign discovering this

--- a/backlink/data/free-channels.json
+++ b/backlink/data/free-channels.json
@@ -1,493 +1,545 @@
 {
- "version": 1,
- "updatedAt": "2026-08-18T04:42:52.276Z",
- "channels": [
-  {
-   "id": "telegraph",
-   "name": "telegra.ph (graph.org mirror)",
-   "kind": "publish-platform",
-   "scope": "single-site",
-   "homepage": "https://telegra.ph",
-   "account": "none",
-   "captcha": "none",
-   "browserRequired": false,
-   "anchorRendered": true,
-   "relObserved": [
-    "nofollow"
-   ],
-   "robotsObserved": "index, follow",
-   "indexable": true,
-   "rateLimit": null,
-   "howToPublish": "Pure HTTP API, no browser at all: createAccount then createPage. Both must be POST — GET silently misbehaves.",
-   "traps": [
-    "Body anchors are nofollow; the ONE dofollow link per page is the byline, built from the author_url passed at publish time. Point author_url at the URL you actually want the dofollow to reach.",
-    "This record read 'dofollow' for a while because a check sampled a single anchor — the byline — and generalised. Read rel from EVERY anchor before recording it."
-   ],
-   "status": "live",
-   "lastVerifiedAt": "2026-08-17",
-   "evidence": {
-    "method": "anonymous-http",
-    "what": "Every anchor across six published pages on both hosts was read from raw HTML; body links carried rel=nofollow throughout while the byline did not.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "write-as",
-   "name": "write.as",
-   "kind": "publish-platform",
-   "scope": "single-site",
-   "homepage": "https://write.as",
-   "account": "none",
-   "captcha": "none",
-   "browserRequired": true,
-   "anchorRendered": true,
-   "relObserved": [
-    "nofollow"
-   ],
-   "robotsObserved": null,
-   "indexable": true,
-   "howToPublish": "Browser, plain textarea. No editor API needed.",
-   "traps": [],
-   "status": "live",
-   "lastVerifiedAt": "2026-08-17",
-   "evidence": {
-    "method": "browser-dom",
-    "what": "Published page rendered a real anchor with rel=nofollow and carried no robots meta tag.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "rentry-co",
-   "name": "rentry.co",
-   "kind": "paste",
-   "scope": "single-site",
-   "homepage": "https://rentry.co",
-   "account": "none",
-   "captcha": "none",
-   "browserRequired": true,
-   "anchorRendered": true,
-   "relObserved": [],
-   "robotsObserved": "noindex",
-   "indexable": false,
-   "howToPublish": "Browser; the editor is CodeMirror, so set content with .setValue() rather than by assigning to a textarea value.",
-   "traps": [
-    "The dofollow link is real but the hosting page is noindex, which cancels most of the ranking value. Do not let 'dofollow' alone promote this record."
-   ],
-   "status": "rejected",
-   "rejectReason": "Page-level noindex",
-   "lastVerifiedAt": "2026-08-17",
-   "evidence": {
-    "method": "browser-dom",
-    "what": "Published page emitted an anchor with no rel attribute, and the document head carried a noindex robots meta.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "atabook-guestbooks",
-   "name": "Atabook-powered guestbooks",
-   "kind": "guestbook-engine",
-   "scope": "engine",
-   "homepage": "https://atabook.org",
-   "account": "none",
-   "captcha": "passive",
-   "browserRequired": true,
-   "anchorRendered": true,
-   "relObserved": [
-    "noopener noreferrer ugc"
-   ],
-   "robotsObserved": "varies",
-   "indexable": "per-host",
-   "rateLimit": "Per address across the WHOLE engine, not per board. Refusals begin around the eighth or ninth post in a sitting: 'Too many posts from your address. Try again in a few hours.'",
-   "howToPublish": "Browser. Write the link into the message body as BBCode [URL=…]text[/URL]; the server renders a real anchor, so there is no need to drive the rich-text editor.",
-   "traps": [
-    "The bot check is instantiated ON SUBMIT, not on load. Waiting for a token before clicking times out every time and misreports as 'blocked'. Click submit first, then observe.",
-    "A plain HTTP POST returns 200 and silently saves nothing. Only the verification step catches this, never the response code.",
-    "Board owners independently configure an anti-bot question (a question-<id> field) and the robots tag. On a 30-board sample, 14 had a question — the majority. Realistic postable rate after screening was about 45%.",
-    "Rate-limit failures are silent: no redirect, no HTTP error, only an inline ⚠ Error banner above the form. Read that banner after every submit or throttling is indistinguishable from rejection.",
-    "A hidden field named like a password with tabindex=-1 is a honeypot. Never fill it."
-   ],
-   "status": "live",
-   "lastVerifiedAt": "2026-08-18",
-   "evidence": {
-    "method": "both",
-    "what": "Eleven placements published and then re-read over anonymous cookie-less HTTP; each rendered rel=\"noopener noreferrer ugc\", and the hosting boards carried no robots meta.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "statshow",
-   "name": "statshow.com",
-   "kind": "domain-report",
-   "scope": "single-site",
-   "urlPattern": "https://www.statshow.com/www/{domain}",
-   "account": "none",
-   "captcha": "none",
-   "browserRequired": true,
-   "anchorRendered": true,
-   "relObserved": [
-    "",
-    "nofollow"
-   ],
-   "robotsObserved": "index,follow",
-   "indexable": true,
-   "howToPublish": "Visiting the templated URL is the entire submission — the report page is generated on demand.",
-   "traps": [
-    "Raw HTML shows no anchor; the links only exist after client-side rendering. A plain fetch produces a false negative here."
-   ],
-   "status": "live",
-   "lastVerifiedAt": "2026-08-18",
-   "evidence": {
-    "method": "browser-dom",
-    "what": "Nine anchors to the subject domain in the rendered DOM, some with no rel attribute at all, on a page serving robots index,follow.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "domain-glass",
-   "name": "domain.glass",
-   "kind": "domain-report",
-   "scope": "single-site",
-   "urlPattern": "https://www.domain.glass/{domain}",
-   "account": "none",
-   "captcha": "none",
-   "browserRequired": true,
-   "anchorRendered": true,
-   "relObserved": [
-    "",
-    "nofollow",
-    "nofollow noopener noreferrer",
-    "external nofollow noopener noreferrer"
-   ],
-   "robotsObserved": "index, follow, max-image-preview:large",
-   "indexable": true,
-   "howToPublish": "Visiting the templated URL generates the report page.",
-   "traps": [
-    "Mixed rel values on the same page — some anchors carry none. Record the whole set, not the first one you happen to read."
-   ],
-   "status": "live",
-   "lastVerifiedAt": "2026-08-18",
-   "evidence": {
-    "method": "browser-dom",
-    "what": "Twenty anchors to the subject domain in the rendered DOM with a mix of rel values including bare anchors, on an index,follow page.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "sitelike-org",
-   "name": "sitelike.org",
-   "kind": "domain-report",
-   "scope": "single-site",
-   "urlPattern": "https://www.sitelike.org/similar/{domain}/",
-   "account": "none",
-   "captcha": "none",
-   "browserRequired": false,
-   "anchorRendered": true,
-   "relObserved": [
-    "external nofollow noopener"
-   ],
-   "robotsObserved": null,
-   "indexable": true,
-   "howToPublish": "Visiting the templated URL generates the similar-sites page.",
-   "traps": [],
-   "status": "live",
-   "lastVerifiedAt": "2026-08-18",
-   "evidence": {
-    "method": "anonymous-http",
-    "what": "One anchor to the subject domain present in raw HTML with rel='external nofollow noopener'; no robots meta on the page.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "hypestat",
-   "name": "hypestat.com",
-   "kind": "domain-report",
-   "scope": "single-site",
-   "urlPattern": "https://hypestat.com/info/{domain}",
-   "account": "none",
-   "captcha": "none",
-   "browserRequired": true,
-   "anchorRendered": false,
-   "robotsObserved": "noindex,follow",
-   "indexable": false,
-   "howToPublish": "N/A",
-   "traps": [
-    "Representative of most of this family: the page generates fine and looks like a win, but it is noindex. Checking only that the URL loads passes a pile of worthless pages."
-   ],
-   "status": "rejected",
-   "rejectReason": "noindex, and no anchor to the subject domain in the rendered DOM",
-   "lastVerifiedAt": "2026-08-18",
-   "evidence": {
-    "method": "browser-dom",
-    "what": "Rendered DOM contained zero anchors to the subject domain and the page served robots noindex,follow.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "htmlcommentbox",
-   "name": "HTML Comment Box (embedded widget)",
-   "kind": "comment-form",
-   "scope": "engine",
-   "homepage": "https://www.htmlcommentbox.com",
-   "account": "none",
-   "captcha": "unknown",
-   "browserRequired": true,
-   "anchorRendered": true,
-   "robotsObserved": "varies",
-   "indexable": "per-host",
-   "howToPublish": "Browser. The widget is embedded by the host site; the comment stream renders client-side.",
-   "traps": [
-    "Spam saturation is per embedding, NOT per widget. A blanket rejection of this product was recorded from one bad instance; other embeddings carry ordinary human conversation with zero spam, because the embedding owner has moderation controls.",
-    "The comment stream is client-rendered, so a plain HTTP fetch shows a near-empty page and finds no spam. That is a false clear — check the neighbourhood in a browser."
-   ],
-   "status": "unverified",
-   "lastVerifiedAt": "2026-08-18",
-   "evidence": {
-    "method": "browser-dom",
-    "what": "One embedding rendered a real human comment thread in the browser with zero spam-term hits, while plain HTTP returned only 2439 characters of page text and could not see the stream at all.",
-    "publicUrl": "https://solarcircuits.neocities.org/guestbook"
-   }
-  },
-  {
-   "id": "supertools-rundown",
-   "name": "Supertools (therundown.ai)",
-   "kind": "directory",
-   "scope": "single-site",
-   "homepage": "https://supertools.therundown.ai/submit",
-   "account": "none",
-   "captcha": "none",
-   "browserRequired": false,
-   "anchorRendered": true,
-   "robotsObserved": null,
-   "indexable": true,
-   "howToPublish": "Embedded Tally.so form on /submit. No login, no payment, no CAPTCHA.",
-   "traps": [
-    "Listing is reviewed, so submission is not publication — verify the live listing before recording any rel."
-   ],
-   "status": "unverified",
-   "lastVerifiedAt": "2026-08-18",
-   "evidence": {
-    "method": "both",
-    "what": "Raw HTML grepped for recaptcha/hcaptcha/turnstile/sitekey returned nothing, no login wording and no price in script-stripped visible text, and a headless browser pass showed a reachable Tally form.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "dofollow-tools",
-   "name": "Dofollow.Tools",
-   "kind": "directory",
-   "scope": "single-site",
-   "homepage": "https://dofollow.tools/submit",
-   "account": "none",
-   "captcha": "unknown",
-   "browserRequired": true,
-   "anchorRendered": true,
-   "robotsObserved": null,
-   "indexable": true,
-   "howToPublish": "Native multi-step wizard. Step 1 (Tool Information) is reachable with no login wall and no CAPTCHA.",
-   "traps": [
-    "Only step 1 was walked. Step 2 is named \"Submission Type\", which is usually where a free/paid tier choice lives — treat the channel as unverified until someone walks that step.",
-    "The header carries a \"Sign In\" link, but it is navigation, not a wall: the step-1 form renders and is fillable without it. Matching on the words alone gives a false positive."
-   ],
-   "status": "unverified",
-   "lastVerifiedAt": "2026-08-18",
-   "evidence": {
-    "method": "both",
-    "what": "Step-1 form fields render in raw HTML; script-stripped visible text contains no price and no login requirement; no CAPTCHA sitekey string anywhere in the source.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "legacy-php-directory-script",
-   "name": "Legacy PHP directory script (one engine, several hosts)",
-   "kind": "directory",
-   "scope": "engine",
-   "account": "none",
-   "captcha": "unknown",
-   "browserRequired": false,
-   "anchorRendered": true,
-   "robotsObserved": "varies",
-   "indexable": "per-host",
-   "howToPublish": "Server-rendered submit.php with a free tier. Fields and markup are identical across hosts running this script.",
-   "traps": [
-    "Two of the three hosts measured carry a classic image CAPTCHA exposed only as form fields (name=\"CAPTCHA\" plus name=\"IMAGEHASH\"). No third-party script is loaded, so a recaptcha/hcaptcha/turnstile search returns clean on them — search the field names too.",
-    "Whether the CAPTCHA is present is a per-host choice on the same engine, so it must be probed per host like every other owner-level setting."
-   ],
-   "status": "unverified",
-   "lastVerifiedAt": "2026-08-18",
-   "evidence": {
-    "method": "anonymous-http",
-    "what": "Three hosts served byte-similar submit.php markup with identical field names; a service-name CAPTCHA search returned false on all three while two exposed IMAGEHASH and CAPTCHA form fields.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "qualityinternetdirectory",
-   "name": "qualityinternetdirectory.com",
-   "kind": "directory",
-   "scope": "single-site",
-   "homepage": "https://www.qualityinternetdirectory.com/submit.php",
-   "account": "none",
-   "captcha": "none",
-   "browserRequired": false,
-   "anchorRendered": true,
-   "robotsObserved": null,
-   "indexable": true,
-   "howToPublish": "submit.php, free tier, no account. The only host of this legacy engine measured without a CAPTCHA field.",
-   "traps": [
-    "Same engine as the sibling hosts that DO carry an image CAPTCHA — re-check the field names before each campaign, since this is an owner-level setting that can be turned on."
-   ],
-   "status": "unverified",
-   "lastVerifiedAt": "2026-08-18",
-   "evidence": {
-    "method": "anonymous-http",
-    "what": "submit.php returned 200 with a free tier in script-stripped visible text, no price, and neither modern CAPTCHA service strings nor legacy CAPTCHA/IMAGEHASH field names.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "brownbook",
-   "name": "Brownbook",
-   "kind": "directory",
-   "scope": "single-site",
-   "homepage": "https://www.brownbook.net/",
-   "account": "none",
-   "captcha": "none",
-   "browserRequired": true,
-   "anchorRendered": true,
-   "robotsObserved": null,
-   "indexable": true,
-   "howToPublish": "Add-business wizard. Step 1 reachable with no account, no payment and no CAPTCHA.",
-   "traps": [
-    "Only step 1 of a two-step wizard was walked, so a late gate on step 2 is not ruled out."
-   ],
-   "status": "unverified",
-   "lastVerifiedAt": "2026-08-18",
-   "evidence": {
-    "method": "both",
-    "what": "Homepage and add-business step 1 rendered in a browser with no login wall, no price and no CAPTCHA strings or legacy CAPTCHA field names in source.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "aitoolsguide",
-   "name": "AI Tools Guide",
-   "kind": "directory",
-   "scope": "single-site",
-   "homepage": "https://www.aitoolsguide.com/",
-   "account": "none",
-   "captcha": "none",
-   "browserRequired": false,
-   "anchorRendered": true,
-   "robotsObserved": null,
-   "indexable": true,
-   "howToPublish": "免费提交表单，无登录墙、无验证码、无价格",
-   "traps": [
-    "Reviewed listing, so submitting is not publishing — verify the live listing before recording any rel."
-   ],
-   "status": "unverified",
-   "lastVerifiedAt": "2026-08-18",
-   "evidence": {
-    "method": "both",
-    "what": "Submission form present in source; script-stripped visible text carried no price and no login requirement; neither modern CAPTCHA service strings nor legacy CAPTCHA/IMAGEHASH field names were found.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "ainavhub",
-   "name": "AI NavHub",
-   "kind": "directory",
-   "scope": "single-site",
-   "homepage": "https://ainavhub.com/",
-   "account": "none",
-   "captcha": "none",
-   "browserRequired": false,
-   "anchorRendered": true,
-   "robotsObserved": null,
-   "indexable": true,
-   "howToPublish": "同上",
-   "traps": [
-    "Reviewed listing, so submitting is not publishing — verify the live listing before recording any rel."
-   ],
-   "status": "unverified",
-   "lastVerifiedAt": "2026-08-18",
-   "evidence": {
-    "method": "both",
-    "what": "Submission form present in source; script-stripped visible text carried no price and no login requirement; neither modern CAPTCHA service strings nor legacy CAPTCHA/IMAGEHASH field names were found.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "llmrelevance",
-   "name": "LLM Relevance",
-   "kind": "directory",
-   "scope": "single-site",
-   "homepage": "https://llmrelevance.com/",
-   "account": "none",
-   "captcha": "none",
-   "browserRequired": false,
-   "anchorRendered": true,
-   "robotsObserved": null,
-   "indexable": true,
-   "howToPublish": "可见文本里出现 $ 0，与免费档一致",
-   "traps": [
-    "Reviewed listing, so submitting is not publishing — verify the live listing before recording any rel."
-   ],
-   "status": "unverified",
-   "lastVerifiedAt": "2026-08-18",
-   "evidence": {
-    "method": "both",
-    "what": "Submission form present in source; script-stripped visible text carried no price and no login requirement; neither modern CAPTCHA service strings nor legacy CAPTCHA/IMAGEHASH field names were found.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "activesearchresults",
-   "name": "ActiveSearchResults",
-   "kind": "directory",
-   "scope": "single-site",
-   "homepage": "https://www.activesearchresults.com/",
-   "account": "none",
-   "captcha": "none",
-   "browserRequired": false,
-   "anchorRendered": true,
-   "robotsObserved": null,
-   "indexable": true,
-   "howToPublish": "老派搜索目录，免费提交表单",
-   "traps": [
-    "Reviewed listing, so submitting is not publishing — verify the live listing before recording any rel."
-   ],
-   "status": "unverified",
-   "lastVerifiedAt": "2026-08-18",
-   "evidence": {
-    "method": "both",
-    "what": "Submission form present in source; script-stripped visible text carried no price and no login requirement; neither modern CAPTCHA service strings nor legacy CAPTCHA/IMAGEHASH field names were found.",
-    "publicUrl": null
-   }
-  },
-  {
-   "id": "toolai",
-   "name": "ToolAI",
-   "kind": "directory",
-   "scope": "single-site",
-   "homepage": "https://www.toolai.io/submit/tool",
-   "account": "none",
-   "payment": "optional",
-   "captcha": "none",
-   "browserRequired": false,
-   "anchorRendered": true,
-   "robotsObserved": null,
-   "indexable": true,
-   "howToPublish": "Free submission form (name / website / description), no login required to fill it.",
-   "traps": [
-    "**The free tier is explicitly nofollow.** The paid tier ($99, discounted to $49 first month) is what buys a dofollow link and priority review. Free still gets a listing, so record it as a channel — but never record dofollow here without observing it."
-   ],
-   "status": "unverified",
-   "lastVerifiedAt": "2026-08-18",
-   "evidence": {
-    "method": "browser-dom",
-    "what": "Free form fillable without login; the paid plan panel states dofollow and priority review as its paid features, implying the free listing is nofollow.",
-    "publicUrl": null
-   }
-  }
- ]
+  "version": 1,
+  "updatedAt": "2026-08-18T00:00:00.000Z",
+  "channels": [
+    {
+      "id": "telegraph",
+      "name": "telegra.ph (graph.org mirror)",
+      "kind": "publish-platform",
+      "scope": "single-site",
+      "homepage": "https://telegra.ph",
+      "account": "none",
+      "captcha": "none",
+      "browserRequired": false,
+      "anchorRendered": true,
+      "relObserved": [
+        "nofollow"
+      ],
+      "robotsObserved": "index, follow",
+      "indexable": true,
+      "rateLimit": null,
+      "howToPublish": "Pure HTTP API, no browser at all: createAccount then createPage. Both must be POST — GET silently misbehaves.",
+      "traps": [
+        "Body anchors are nofollow; the ONE dofollow link per page is the byline, built from the author_url passed at publish time. Point author_url at the URL you actually want the dofollow to reach.",
+        "This record read 'dofollow' for a while because a check sampled a single anchor — the byline — and generalised. Read rel from EVERY anchor before recording it."
+      ],
+      "status": "live",
+      "lastVerifiedAt": "2026-08-17",
+      "evidence": {
+        "method": "anonymous-http",
+        "what": "Every anchor across six published pages on both hosts was read from raw HTML; body links carried rel=nofollow throughout while the byline did not.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "write-as",
+      "name": "write.as",
+      "kind": "publish-platform",
+      "scope": "single-site",
+      "homepage": "https://write.as",
+      "account": "none",
+      "captcha": "none",
+      "browserRequired": true,
+      "anchorRendered": true,
+      "relObserved": [
+        "nofollow"
+      ],
+      "robotsObserved": null,
+      "indexable": true,
+      "howToPublish": "Browser, plain textarea. No editor API needed.",
+      "traps": [],
+      "status": "live",
+      "lastVerifiedAt": "2026-08-17",
+      "evidence": {
+        "method": "browser-dom",
+        "what": "Published page rendered a real anchor with rel=nofollow and carried no robots meta tag.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "rentry-co",
+      "name": "rentry.co",
+      "kind": "paste",
+      "scope": "single-site",
+      "homepage": "https://rentry.co",
+      "account": "none",
+      "captcha": "none",
+      "browserRequired": true,
+      "anchorRendered": true,
+      "relObserved": [],
+      "robotsObserved": "noindex",
+      "indexable": false,
+      "howToPublish": "Browser; the editor is CodeMirror, so set content with .setValue() rather than by assigning to a textarea value.",
+      "traps": [
+        "The dofollow link is real but the hosting page is noindex, which cancels most of the ranking value. Do not let 'dofollow' alone promote this record."
+      ],
+      "status": "rejected",
+      "rejectReason": "Page-level noindex",
+      "lastVerifiedAt": "2026-08-17",
+      "evidence": {
+        "method": "browser-dom",
+        "what": "Published page emitted an anchor with no rel attribute, and the document head carried a noindex robots meta.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "atabook-guestbooks",
+      "name": "Atabook-powered guestbooks",
+      "kind": "guestbook-engine",
+      "scope": "engine",
+      "homepage": "https://atabook.org",
+      "account": "none",
+      "captcha": "passive",
+      "browserRequired": true,
+      "anchorRendered": true,
+      "relObserved": [
+        "noopener noreferrer ugc"
+      ],
+      "robotsObserved": "varies",
+      "indexable": "per-host",
+      "rateLimit": "Per address across the WHOLE engine, not per board. Refusals begin around the eighth or ninth post in a sitting: 'Too many posts from your address. Try again in a few hours.'",
+      "howToPublish": "Browser. Write the link into the message body as BBCode [URL=…]text[/URL]; the server renders a real anchor, so there is no need to drive the rich-text editor.",
+      "traps": [
+        "The bot check is instantiated ON SUBMIT, not on load. Waiting for a token before clicking times out every time and misreports as 'blocked'. Click submit first, then observe.",
+        "A plain HTTP POST returns 200 and silently saves nothing. Only the verification step catches this, never the response code.",
+        "Board owners independently configure an anti-bot question (a question-<id> field) and the robots tag. On a 30-board sample, 14 had a question — the majority. Realistic postable rate after screening was about 45%.",
+        "Rate-limit failures are silent: no redirect, no HTTP error, only an inline ⚠ Error banner above the form. Read that banner after every submit or throttling is indistinguishable from rejection.",
+        "A hidden field named like a password with tabindex=-1 is a honeypot. Never fill it."
+      ],
+      "status": "live",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "both",
+        "what": "Eleven placements published and then re-read over anonymous cookie-less HTTP; each rendered rel=\"noopener noreferrer ugc\", and the hosting boards carried no robots meta.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "statshow",
+      "name": "statshow.com",
+      "kind": "domain-report",
+      "scope": "single-site",
+      "urlPattern": "https://www.statshow.com/www/{domain}",
+      "account": "none",
+      "captcha": "none",
+      "browserRequired": true,
+      "anchorRendered": true,
+      "relObserved": [
+        "",
+        "nofollow"
+      ],
+      "robotsObserved": "index,follow",
+      "indexable": true,
+      "howToPublish": "Visiting the templated URL is the entire submission — the report page is generated on demand.",
+      "traps": [
+        "Raw HTML shows no anchor; the links only exist after client-side rendering. A plain fetch produces a false negative here."
+      ],
+      "status": "live",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "browser-dom",
+        "what": "Nine anchors to the subject domain in the rendered DOM, some with no rel attribute at all, on a page serving robots index,follow.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "domain-glass",
+      "name": "domain.glass",
+      "kind": "domain-report",
+      "scope": "single-site",
+      "urlPattern": "https://www.domain.glass/{domain}",
+      "account": "none",
+      "captcha": "none",
+      "browserRequired": true,
+      "anchorRendered": true,
+      "relObserved": [
+        "",
+        "nofollow",
+        "nofollow noopener noreferrer",
+        "external nofollow noopener noreferrer"
+      ],
+      "robotsObserved": "index, follow, max-image-preview:large",
+      "indexable": true,
+      "howToPublish": "Visiting the templated URL generates the report page.",
+      "traps": [
+        "Mixed rel values on the same page — some anchors carry none. Record the whole set, not the first one you happen to read."
+      ],
+      "status": "live",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "browser-dom",
+        "what": "Twenty anchors to the subject domain in the rendered DOM with a mix of rel values including bare anchors, on an index,follow page.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "sitelike-org",
+      "name": "sitelike.org",
+      "kind": "domain-report",
+      "scope": "single-site",
+      "urlPattern": "https://www.sitelike.org/similar/{domain}/",
+      "account": "none",
+      "captcha": "none",
+      "browserRequired": false,
+      "anchorRendered": true,
+      "relObserved": [
+        "external nofollow noopener"
+      ],
+      "robotsObserved": null,
+      "indexable": true,
+      "howToPublish": "Visiting the templated URL generates the similar-sites page.",
+      "traps": [],
+      "status": "live",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "anonymous-http",
+        "what": "One anchor to the subject domain present in raw HTML with rel='external nofollow noopener'; no robots meta on the page.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "hypestat",
+      "name": "hypestat.com",
+      "kind": "domain-report",
+      "scope": "single-site",
+      "urlPattern": "https://hypestat.com/info/{domain}",
+      "account": "none",
+      "captcha": "none",
+      "browserRequired": true,
+      "anchorRendered": false,
+      "robotsObserved": "noindex,follow",
+      "indexable": false,
+      "howToPublish": "N/A",
+      "traps": [
+        "Representative of most of this family: the page generates fine and looks like a win, but it is noindex. Checking only that the URL loads passes a pile of worthless pages."
+      ],
+      "status": "rejected",
+      "rejectReason": "noindex, and no anchor to the subject domain in the rendered DOM",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "browser-dom",
+        "what": "Rendered DOM contained zero anchors to the subject domain and the page served robots noindex,follow.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "htmlcommentbox",
+      "name": "HTML Comment Box (embedded widget)",
+      "kind": "comment-form",
+      "scope": "engine",
+      "homepage": "https://www.htmlcommentbox.com",
+      "account": "none",
+      "captcha": "unknown",
+      "browserRequired": true,
+      "anchorRendered": true,
+      "robotsObserved": "varies",
+      "indexable": "per-host",
+      "howToPublish": "Browser. The widget is embedded by the host site; the comment stream renders client-side.",
+      "traps": [
+        "Spam saturation is per embedding, NOT per widget. A blanket rejection of this product was recorded from one bad instance; other embeddings carry ordinary human conversation with zero spam, because the embedding owner has moderation controls.",
+        "The comment stream is client-rendered, so a plain HTTP fetch shows a near-empty page and finds no spam. That is a false clear — check the neighbourhood in a browser."
+      ],
+      "status": "unverified",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "browser-dom",
+        "what": "One embedding rendered a real human comment thread in the browser with zero spam-term hits, while plain HTTP returned only 2439 characters of page text and could not see the stream at all.",
+        "publicUrl": "https://solarcircuits.neocities.org/guestbook"
+      }
+    },
+    {
+      "id": "supertools-rundown",
+      "name": "Supertools (therundown.ai)",
+      "kind": "directory",
+      "scope": "single-site",
+      "homepage": "https://supertools.therundown.ai/submit",
+      "account": "none",
+      "captcha": "none",
+      "browserRequired": false,
+      "anchorRendered": true,
+      "robotsObserved": null,
+      "indexable": true,
+      "howToPublish": "Embedded Tally.so form on /submit. No login, no payment, no CAPTCHA.",
+      "traps": [
+        "Listing is reviewed, so submission is not publication — verify the live listing before recording any rel."
+      ],
+      "status": "unverified",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "both",
+        "what": "Raw HTML grepped for recaptcha/hcaptcha/turnstile/sitekey returned nothing, no login wording and no price in script-stripped visible text, and a headless browser pass showed a reachable Tally form.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "dofollow-tools",
+      "name": "Dofollow.Tools",
+      "kind": "directory",
+      "scope": "single-site",
+      "homepage": "https://dofollow.tools/submit",
+      "account": "none",
+      "captcha": "unknown",
+      "browserRequired": true,
+      "anchorRendered": true,
+      "robotsObserved": null,
+      "indexable": true,
+      "howToPublish": "Native multi-step wizard. Step 1 (Tool Information) is reachable with no login wall and no CAPTCHA.",
+      "traps": [
+        "Only step 1 was walked. Step 2 is named \"Submission Type\", which is usually where a free/paid tier choice lives — treat the channel as unverified until someone walks that step.",
+        "The header carries a \"Sign In\" link, but it is navigation, not a wall: the step-1 form renders and is fillable without it. Matching on the words alone gives a false positive."
+      ],
+      "status": "unverified",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "both",
+        "what": "Step-1 form fields render in raw HTML; script-stripped visible text contains no price and no login requirement; no CAPTCHA sitekey string anywhere in the source.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "legacy-php-directory-script",
+      "name": "Legacy PHP directory script (one engine, several hosts)",
+      "kind": "directory",
+      "scope": "engine",
+      "account": "none",
+      "captcha": "unknown",
+      "browserRequired": false,
+      "anchorRendered": true,
+      "robotsObserved": "varies",
+      "indexable": "per-host",
+      "howToPublish": "Server-rendered submit.php with a free tier. Fields and markup are identical across hosts running this script.",
+      "traps": [
+        "Two of the three hosts measured carry a classic image CAPTCHA exposed only as form fields (name=\"CAPTCHA\" plus name=\"IMAGEHASH\"). No third-party script is loaded, so a recaptcha/hcaptcha/turnstile search returns clean on them — search the field names too.",
+        "Whether the CAPTCHA is present is a per-host choice on the same engine, so it must be probed per host like every other owner-level setting."
+      ],
+      "status": "unverified",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "anonymous-http",
+        "what": "Three hosts served byte-similar submit.php markup with identical field names; a service-name CAPTCHA search returned false on all three while two exposed IMAGEHASH and CAPTCHA form fields.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "qualityinternetdirectory",
+      "name": "qualityinternetdirectory.com",
+      "kind": "directory",
+      "scope": "single-site",
+      "homepage": "https://www.qualityinternetdirectory.com/submit.php",
+      "account": "none",
+      "captcha": "none",
+      "browserRequired": false,
+      "anchorRendered": true,
+      "robotsObserved": null,
+      "indexable": true,
+      "howToPublish": "submit.php, free tier, no account. The only host of this legacy engine measured without a CAPTCHA field.",
+      "traps": [
+        "Same engine as the sibling hosts that DO carry an image CAPTCHA — re-check the field names before each campaign, since this is an owner-level setting that can be turned on."
+      ],
+      "status": "unverified",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "anonymous-http",
+        "what": "submit.php returned 200 with a free tier in script-stripped visible text, no price, and neither modern CAPTCHA service strings nor legacy CAPTCHA/IMAGEHASH field names.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "brownbook",
+      "name": "Brownbook",
+      "kind": "directory",
+      "scope": "single-site",
+      "homepage": "https://www.brownbook.net/",
+      "account": "none",
+      "captcha": "none",
+      "browserRequired": true,
+      "anchorRendered": true,
+      "robotsObserved": null,
+      "indexable": true,
+      "howToPublish": "Add-business wizard. Step 1 reachable with no account, no payment and no CAPTCHA.",
+      "traps": [
+        "Only step 1 of a two-step wizard was walked, so a late gate on step 2 is not ruled out."
+      ],
+      "status": "unverified",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "both",
+        "what": "Homepage and add-business step 1 rendered in a browser with no login wall, no price and no CAPTCHA strings or legacy CAPTCHA field names in source.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "aitoolsguide",
+      "name": "AI Tools Guide",
+      "kind": "directory",
+      "scope": "single-site",
+      "homepage": "https://www.aitoolsguide.com/",
+      "account": "none",
+      "captcha": "none",
+      "browserRequired": false,
+      "anchorRendered": true,
+      "robotsObserved": null,
+      "indexable": true,
+      "howToPublish": "免费提交表单，无登录墙、无验证码、无价格",
+      "traps": [
+        "Reviewed listing, so submitting is not publishing — verify the live listing before recording any rel."
+      ],
+      "status": "unverified",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "both",
+        "what": "Submission form present in source; script-stripped visible text carried no price and no login requirement; neither modern CAPTCHA service strings nor legacy CAPTCHA/IMAGEHASH field names were found.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "ainavhub",
+      "name": "AI NavHub",
+      "kind": "directory",
+      "scope": "single-site",
+      "homepage": "https://ainavhub.com/",
+      "account": "none",
+      "captcha": "none",
+      "browserRequired": false,
+      "anchorRendered": true,
+      "robotsObserved": null,
+      "indexable": true,
+      "howToPublish": "同上",
+      "traps": [
+        "Reviewed listing, so submitting is not publishing — verify the live listing before recording any rel."
+      ],
+      "status": "unverified",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "both",
+        "what": "Submission form present in source; script-stripped visible text carried no price and no login requirement; neither modern CAPTCHA service strings nor legacy CAPTCHA/IMAGEHASH field names were found.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "llmrelevance",
+      "name": "LLM Relevance",
+      "kind": "directory",
+      "scope": "single-site",
+      "homepage": "https://llmrelevance.com/",
+      "account": "none",
+      "captcha": "none",
+      "browserRequired": false,
+      "anchorRendered": true,
+      "robotsObserved": null,
+      "indexable": true,
+      "howToPublish": "可见文本里出现 $ 0，与免费档一致",
+      "traps": [
+        "Reviewed listing, so submitting is not publishing — verify the live listing before recording any rel."
+      ],
+      "status": "unverified",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "both",
+        "what": "Submission form present in source; script-stripped visible text carried no price and no login requirement; neither modern CAPTCHA service strings nor legacy CAPTCHA/IMAGEHASH field names were found.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "activesearchresults",
+      "name": "ActiveSearchResults",
+      "kind": "directory",
+      "scope": "single-site",
+      "homepage": "https://www.activesearchresults.com/",
+      "account": "none",
+      "captcha": "none",
+      "browserRequired": false,
+      "anchorRendered": true,
+      "robotsObserved": null,
+      "indexable": true,
+      "howToPublish": "老派搜索目录，免费提交表单",
+      "traps": [
+        "Reviewed listing, so submitting is not publishing — verify the live listing before recording any rel."
+      ],
+      "status": "unverified",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "both",
+        "what": "Submission form present in source; script-stripped visible text carried no price and no login requirement; neither modern CAPTCHA service strings nor legacy CAPTCHA/IMAGEHASH field names were found.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "toolai",
+      "name": "ToolAI",
+      "kind": "directory",
+      "scope": "single-site",
+      "homepage": "https://www.toolai.io/submit/tool",
+      "account": "none",
+      "payment": "optional",
+      "captcha": "none",
+      "browserRequired": false,
+      "anchorRendered": true,
+      "robotsObserved": null,
+      "indexable": true,
+      "howToPublish": "Free submission form (name / website / description), no login required to fill it.",
+      "traps": [
+        "**The free tier is explicitly nofollow.** The paid tier ($99, discounted to $49 first month) is what buys a dofollow link and priority review. Free still gets a listing, so record it as a channel — but never record dofollow here without observing it."
+      ],
+      "status": "unverified",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "browser-dom",
+        "what": "Free form fillable without login; the paid plan panel states dofollow and priority review as its paid features, implying the free listing is nofollow.",
+        "publicUrl": null
+      }
+    },
+    {
+      "id": "openpr",
+      "name": "openPR",
+      "kind": "publish-platform",
+      "scope": "single-site",
+      "homepage": "https://www.openpr.com/",
+      "account": "none",
+      "payment": "optional",
+      "captcha": "interactive",
+      "browserRequired": true,
+      "anchorRendered": false,
+      "relObserved": [],
+      "robotsObserved": "index,follow,noarchive",
+      "indexable": true,
+      "howToPublish": "Free press release at /news/submit.html, reachable anonymously — no login wall, only a legacy image CAPTCHA and two consent checkboxes. It publishes; it just does not give you an anchor.",
+      "traps": [
+        "Publishes fine and emits NO anchor for the author. Rendered DOM of a live release carries 127 anchors and not one points at the author domain; the author URLs (arizton.com, four of them) exist only as plain text nodes. Verified in a browser 2026-08-18.",
+        "The page does have outbound anchors with no rel — but they are openPR own properties, a consent-manager, and a sitewide advertiser (einbock.com) that is byte-identical across unrelated releases. Reading those as \"dofollow author link\" is the specific way this site fools a page-level rel scan.",
+        "Every form field name is a per-load random hash (e.g. 8182cb1481cc...), so no script can hardcode field names — it must parse the form on each load.",
+        "The form carries load_credits / credits_code fields: a paid path exists beside the free one. Free submission did not require touching them.",
+        "Generalisation warning: this is one site, not the free-press-release family. Sample each PR site own published item before assuming it behaves the same."
+      ],
+      "status": "rejected",
+      "rejectReason": "Publishes without an account but emits no author anchor at all, so a placement here is worth zero link equity. Rejected on output, not on access.",
+      "lastVerifiedAt": "2026-08-18",
+      "evidence": {
+        "method": "browser-dom",
+        "url": "https://www.openpr.com/news/4606409/middle-east-data-center-construction-investment-to-reach-usd",
+        "what": "Ran document.querySelectorAll on the rendered page: 127 anchors total, outbound anchor hosts were only twitter/facebook/linkedin/google (all rel=nofollow), consentmanager.net and einbock.com (both no rel). The author domain arizton.com appeared four times in document.body.innerText and zero times in any href. Cross-checked against a second unrelated release (/news/4606405) which carried the same einbock.com anchor, confirming it is a sitewide advertiser rather than an author link."
+      }
+    },
+    {
+      "id": "blogengage",
+      "name": "BlogEngage (dead — domain resold)",
+      "kind": "directory",
+      "scope": "single-site",
+      "homepage": "https://blogengage.com/",
+      "account": "required",
+      "captcha": "unknown",
+      "anchorRendered": false,
+      "status": "dead",
+      "lastVerifiedAt": "2026-08-18",
+      "howToPublish": "Nothing to publish. The domain no longer belongs to a blog directory.",
+      "traps": [
+        "Answers HTTP 200 and is still listed as a live blog-promotion directory in widely-copied backlink lists. It now redirects to a crypto product. A status-code check alone passes it; only following the redirect or reading the title catches it."
+      ],
+      "evidence": {
+        "method": "browser-dom",
+        "url": "https://blogengage.com/",
+        "what": "Navigating to blogengage.com in a browser lands on https://gomining.com with the title \"Bitcoin superapp - mining, earning and using BTC | GoMining\". There is no blog directory left at this domain — the site was resold, not merely rebranded."
+      }
+    }
+  ]
 }

--- a/backlink/data/index-submission.json
+++ b/backlink/data/index-submission.json
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "updatedAt": "2026-08-19T00:00:00.000Z",
+  "engines": [
+    {
+      "id": "brave",
+      "name": "Brave Search",
+      "submitUrl": "https://search.brave.com/submit-url",
+      "independentIndex": true,
+      "indexNowMember": false,
+      "webmasterConsole": false,
+      "sitemapAccepted": false,
+      "account": "none",
+      "captcha": "passive",
+      "browserRequired": true,
+      "batch": false,
+      "aiGrounding": {
+        "claimed": true,
+        "source": "https://brave.com/search/api/",
+        "what": "Brave's own API page sells the index for grounding chatbots and AI search, and states it is not a scraper over Google or Bing but Brave's own independent index."
+      },
+      "howToSubmit": "One URL per page load. Load the form, set the input, click Submit with a real click, wait for the passive human check to clear, then read the confirmation text before moving on.",
+      "traps": [
+        "A JS-synthesised button.click() never submits — the passive check requires a trusted event. Injecting the input value with the native value setter is fine; only the click has to be real.",
+        "Enter does not submit. The button is the only path.",
+        "Navigating away during the 2-4s check silently discards the submission. Wait for the confirmation text.",
+        "The button becomes a permanently disabled 'Submitted' after success, so every further URL needs a fresh page load.",
+        "The form ignores a ?url= query parameter — it only reads the input.",
+        "Network-request logs stop recording after an in-page location.reload(), so a missing POST is not evidence of failure. The page's own success text is the only judge."
+      ],
+      "status": "live",
+      "lastVerifiedAt": "2026-08-19",
+      "evidence": {
+        "method": "browser-dom",
+        "what": "Submitted 38 URLs of one owned site through the live form; sampled 12 of them and read 'Success / Thank you for your submission.' off the page each time. The other 26 ran the identical sequence but were not individually re-read.",
+        "publicUrl": null
+      },
+      "notes": "Measured before submitting: site:<domain> returned 1 result on Brave while Google Search Console reported 37 of 38 URLs indexed. Whether the submission moves that number is unresolved — recheck and record the outcome."
+    }
+  ]
+}

--- a/backlink/data/paid-platforms.json
+++ b/backlink/data/paid-platforms.json
@@ -1,1077 +1,1105 @@
 {
- "updatedAt": "2026-08-18T03:33:31.670Z",
- "note": "被观察到用于投放的平台登记表；sitesHit 越高越说明它真的在被使用",
- "platforms": {
-  "microlaunch.net": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": "/premium 页有价，未核。",
-   "observedSites": [
-    "21st.dev"
-   ],
-   "placements": [
-    "21st.dev@2025-02-19"
-   ],
-   "totalUrls": 5
-  },
-  "aiquerytool.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "21st.dev"
-   ],
-   "placements": [
-    "21st.dev@2025-02-19",
-    "21st.dev@2025-05-13",
-    "21st.dev@2025-05-15"
-   ],
-   "totalUrls": 12
-  },
-  "webcurate.co": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "21st.dev"
-   ],
-   "placements": [
-    "21st.dev@2025-04-08",
-    "21st.dev@2025-04-11"
-   ],
-   "totalUrls": 7
-  },
-  "szxn.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "21st.dev"
-   ],
-   "placements": [
-    "21st.dev@2025-05-01",
-    "21st.dev@2025-05-26",
-    "21st.dev@2025-05-27",
-    "21st.dev@2025-05-30",
-    "21st.dev@2025-06-04",
-    "21st.dev@2025-06-09",
-    "21st.dev@2025-06-12"
-   ],
-   "totalUrls": 25
-  },
-  "sparkbites.dev": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "21st.dev"
-   ],
-   "placements": [
-    "21st.dev@2025-05-19"
-   ],
-   "totalUrls": 3
-  },
-  "adspirer.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "adspirer.ai"
-   ],
-   "placements": [
-    "adspirer.ai@2025-12-21",
-    "adspirer.ai@2025-12-30",
-    "adspirer.ai@2025-12-31",
-    "adspirer.ai@2026-01-08",
-    "adspirer.ai@2026-01-09",
-    "adspirer.ai@2026-01-10",
-    "adspirer.ai@2026-01-19",
-    "adspirer.ai@2026-02-10",
-    "adspirer.ai@2026-03-25",
-    "adspirer.ai@2026-03-31",
-    "adspirer.ai@2026-04-04",
-    "adspirer.ai@2026-04-05",
-    "adspirer.ai@2026-04-10",
-    "adspirer.ai@2026-04-27",
-    "adspirer.ai@2026-04-30",
-    "adspirer.ai@2026-05-02",
-    "adspirer.ai@2026-05-03",
-    "adspirer.ai@2026-05-05",
-    "adspirer.ai@2026-05-06"
-   ],
-   "totalUrls": 159
-  },
-  "developer.adspirer.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "adspirer.ai"
-   ],
-   "placements": [
-    "adspirer.ai@2026-04-24"
-   ],
-   "totalUrls": 11
-  },
-  "prismo.fedibird.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "aiattractivenesstest.ai"
-   ],
-   "placements": [
-    "aiattractivenesstest.ai@2026-04-02"
-   ],
-   "totalUrls": 3
-  },
-  "blogs.dickinson.edu": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "aiattractivenesstest.ai"
-   ],
-   "placements": [
-    "aiattractivenesstest.ai@2026-04-03"
-   ],
-   "totalUrls": 4
-  },
-  "spillhistorie.no": {
-   "tier": "not-a-platform",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": "挪威游戏史站，单站 388 条。同上，先当异常看待而不是渠道。",
-   "observedSites": [
-    "aiattractivenesstest.ai"
-   ],
-   "placements": [
-    "aiattractivenesstest.ai@2026-04-03"
-   ],
-   "totalUrls": 388
-  },
-  "gptdemo.net": {
-   "tier": "link-package",
-   "price": "同上（一份钱覆盖两个域）",
-   "priceCheckedAt": "2026-08-18",
-   "notes": "aitoolhub.net 的姊妹域，见该条。",
-   "observedSites": [
-    "capafy.ai",
-    "eimg.ai",
-    "fontvibe.ai",
-    "imagefree.net"
-   ],
-   "placements": [
-    "capafy.ai@2026-06-02",
-    "eimg.ai@2026-07-18",
-    "eimg.ai@2026-07-19",
-    "fontvibe.ai@2026-04-21",
-    "imagefree.net@2026-03-20",
-    "imagefree.net@2026-03-21"
-   ],
-   "totalUrls": 364
-  },
-  "aitoolhub.net": {
-   "tier": "link-package",
-   "price": "$19.9 一次性",
-   "priceCheckedAt": "2026-08-18",
-   "notes": "与 gptdemo.net 同一运营方（分类计数、版式完全一致）。pricing 页直写「24 High-Quality Dofollow Backlinks」：12 个界面语言 x 2 个域 = 24 个页面。所以「单站 148 条」是一次投放，不是多次。",
-   "observedSites": [
-    "capafy.ai",
-    "eimg.ai",
-    "fontvibe.ai",
-    "imagefree.net"
-   ],
-   "placements": [
-    "capafy.ai@2026-06-02",
-    "eimg.ai@2026-07-18",
-    "fontvibe.ai@2026-04-21",
-    "imagefree.net@2026-03-20",
-    "imagefree.net@2026-03-21"
-   ],
-   "totalUrls": 444
-  },
-  "toolatlas.io": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "capafy.ai",
-    "fontvibe.ai"
-   ],
-   "placements": [
-    "capafy.ai@2026-06-02",
-    "fontvibe.ai@2026-04-20"
-   ],
-   "totalUrls": 11
-  },
-  "mcpservers.org": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "capafy.ai"
-   ],
-   "placements": [
-    "capafy.ai@2026-06-02"
-   ],
-   "totalUrls": 19
-  },
-  "toolify.ai": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "capafy.ai",
-    "fontvibe.ai"
-   ],
-   "placements": [
-    "capafy.ai@2026-06-02",
-    "fontvibe.ai@2026-04-20",
-    "fontvibe.ai@2026-04-21"
-   ],
-   "totalUrls": 16
-  },
-  "seopxl-organic-boost-lab.shop": {
-   "tier": "spam-net",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": "域名本身写着 seo/ranking/boost/fiverr 的批量站群。出现在自己反链里是被无关方通投，不是成绩。黑名单，不要买。",
-   "observedSites": [
-    "cliptica.com",
-    "emojer.org"
-   ],
-   "placements": [
-    "cliptica.com@2026-07-24",
-    "cliptica.com@2026-07-26",
-    "emojer.org@2026-07-24",
-    "emojer.org@2026-07-26"
-   ],
-   "totalUrls": 19
-  },
-  "seo-growth-optimization-hub.shop": {
-   "tier": "spam-net",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": "域名本身写着 seo/ranking/boost/fiverr 的批量站群。出现在自己反链里是被无关方通投，不是成绩。黑名单，不要买。",
-   "observedSites": [
-    "cliptica.com",
-    "emojer.org",
-    "make.design"
-   ],
-   "placements": [
-    "cliptica.com@2026-07-24",
-    "cliptica.com@2026-07-25",
-    "cliptica.com@2026-07-26",
-    "emojer.org@2026-07-26",
-    "make.design@2026-06-08"
-   ],
-   "totalUrls": 17
-  },
-  "seopxl-performance-authority-engine.shop": {
-   "tier": "spam-net",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": "域名本身写着 seo/ranking/boost/fiverr 的批量站群。出现在自己反链里是被无关方通投，不是成绩。黑名单，不要买。",
-   "observedSites": [
-    "cliptica.com",
-    "emojer.org",
-    "make.design"
-   ],
-   "placements": [
-    "cliptica.com@2026-07-24",
-    "cliptica.com@2026-07-26",
-    "emojer.org@2026-07-24",
-    "emojer.org@2026-07-26",
-    "make.design@2026-06-06"
-   ],
-   "totalUrls": 25
-  },
-  "seopxl-traffic-growth-lab.shop": {
-   "tier": "spam-net",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": "域名本身写着 seo/ranking/boost/fiverr 的批量站群。出现在自己反链里是被无关方通投，不是成绩。黑名单，不要买。",
-   "observedSites": [
-    "cliptica.com",
-    "emojer.org"
-   ],
-   "placements": [
-    "cliptica.com@2026-07-24",
-    "emojer.org@2026-07-24"
-   ],
-   "totalUrls": 13
-  },
-  "seo-growth-authority-boost-hub.shop": {
-   "tier": "spam-net",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": "域名本身写着 seo/ranking/boost/fiverr 的批量站群。出现在自己反链里是被无关方通投，不是成绩。黑名单，不要买。",
-   "observedSites": [
-    "cliptica.com",
-    "emojer.org"
-   ],
-   "placements": [
-    "cliptica.com@2026-07-24",
-    "emojer.org@2026-07-24"
-   ],
-   "totalUrls": 16
-  },
-  "seopxl-ranking-boost-lab.shop": {
-   "tier": "spam-net",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": "域名本身写着 seo/ranking/boost/fiverr 的批量站群。出现在自己反链里是被无关方通投，不是成绩。黑名单，不要买。",
-   "observedSites": [
-    "cliptica.com",
-    "emojer.org",
-    "make.design"
-   ],
-   "placements": [
-    "cliptica.com@2026-07-25",
-    "emojer.org@2026-07-24",
-    "emojer.org@2026-07-25",
-    "make.design@2026-06-05",
-    "make.design@2026-06-06"
-   ],
-   "totalUrls": 23
-  },
-  "nano-banana.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "eimg.ai"
-   ],
-   "placements": [
-    "eimg.ai@2026-07-11",
-    "eimg.ai@2026-07-12",
-    "eimg.ai@2026-07-13",
-    "eimg.ai@2026-07-14",
-    "eimg.ai@2026-07-15",
-    "eimg.ai@2026-07-16",
-    "eimg.ai@2026-07-17"
-   ],
-   "totalUrls": 108
-  },
-  "madrimasd.org": {
-   "tier": "not-a-platform",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": "西班牙机构站，单站 254 条集中在一天——形态更像站群注入或全站挂件，不是可投放的平台。别当渠道用。",
-   "observedSites": [
-    "eimg.ai",
-    "magicremover.org"
-   ],
-   "placements": [
-    "eimg.ai@2026-07-13",
-    "magicremover.org@2026-04-23",
-    "magicremover.org@2026-04-24"
-   ],
-   "totalUrls": 292
-  },
-  "aegypten-ausflug.de": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "eimg.ai"
-   ],
-   "placements": [
-    "eimg.ai@2026-07-13"
-   ],
-   "totalUrls": 5
-  },
-  "heroacademiabeyond.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "eimg.ai"
-   ],
-   "placements": [
-    "eimg.ai@2026-07-15"
-   ],
-   "totalUrls": 3
-  },
-  "creati.ai": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "eimg.ai"
-   ],
-   "placements": [
-    "eimg.ai@2026-07-18",
-    "eimg.ai@2026-07-19"
-   ],
-   "totalUrls": 12
-  },
-  "launchitx.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "eimg.ai"
-   ],
-   "placements": [
-    "eimg.ai@2026-07-18",
-    "eimg.ai@2026-07-19"
-   ],
-   "totalUrls": 26
-  },
-  "bestfor.ai": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "eimg.ai"
-   ],
-   "placements": [
-    "eimg.ai@2026-07-18"
-   ],
-   "totalUrls": 3
-  },
-  "showmebest.ai": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "eimg.ai"
-   ],
-   "placements": [
-    "eimg.ai@2026-07-18"
-   ],
-   "totalUrls": 6
-  },
-  "bai.tools": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "eimg.ai"
-   ],
-   "placements": [
-    "eimg.ai@2026-07-18",
-    "eimg.ai@2026-07-19"
-   ],
-   "totalUrls": 8
-  },
-  "mossai.org": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "eimg.ai",
-    "tryonr.com"
-   ],
-   "placements": [
-    "eimg.ai@2026-07-18",
-    "eimg.ai@2026-07-19",
-    "tryonr.com@2025-12-17",
-    "tryonr.com@2025-12-18",
-    "tryonr.com@2025-12-21",
-    "tryonr.com@2025-12-22",
-    "tryonr.com@2025-12-26",
-    "tryonr.com@2025-12-27",
-    "tryonr.com@2025-12-28",
-    "tryonr.com@2025-12-29",
-    "tryonr.com@2025-12-30",
-    "tryonr.com@2025-12-31",
-    "tryonr.com@2026-01-01",
-    "tryonr.com@2026-01-04",
-    "tryonr.com@2026-01-05",
-    "tryonr.com@2026-01-06",
-    "tryonr.com@2026-01-07",
-    "tryonr.com@2026-01-08",
-    "tryonr.com@2026-01-09",
-    "tryonr.com@2026-01-10"
-   ],
-   "totalUrls": 94
-  },
-  "iuu.ai": {
-   "tier": "free-with-account",
-   "price": "$0（但要注册）",
-   "priceCheckedAt": "2026-08-18",
-   "notes": "FAQ 白纸黑字写 fee is currently $0，但提交按钮本身就是 Login。「免费」与「免注册」是两件事。",
-   "observedSites": [
-    "eimg.ai"
-   ],
-   "placements": [
-    "eimg.ai@2026-07-18",
-    "eimg.ai@2026-07-19"
-   ],
-   "totalUrls": 8
-  },
-  "ai.keenchase.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "eimg.ai"
-   ],
-   "placements": [
-    "eimg.ai@2026-07-18"
-   ],
-   "totalUrls": 4
-  },
-  "aistage.net": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "eimg.ai"
-   ],
-   "placements": [
-    "eimg.ai@2026-07-19"
-   ],
-   "totalUrls": 3
-  },
-  "www3.wind.ne.jp": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "eimg.ai"
-   ],
-   "placements": [
-    "eimg.ai@2026-07-19"
-   ],
-   "totalUrls": 3
-  },
-  "emojer.ru": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "emojer.org"
-   ],
-   "placements": [
-    "emojer.org@2026-07-16",
-    "emojer.org@2026-08-01"
-   ],
-   "totalUrls": 7
-  },
-  "cqiar.blogspot.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "fancytextguru.com"
-   ],
-   "placements": [
-    "fancytextguru.com@2024-01-14"
-   ],
-   "totalUrls": 3
-  },
-  "the-bulldog.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "fancytextguru.com",
-    "textfx.co"
-   ],
-   "placements": [
-    "fancytextguru.com@2024-08-12",
-    "textfx.co@2025-04-18"
-   ],
-   "totalUrls": 10
-  },
-  "saashunt.best": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": "有 Submit Project 与 Pricing，首页自述「Submit, Earn a Badge, High DR Backlink」。",
-   "observedSites": [
-    "fontsgeneratorpro.com"
-   ],
-   "placements": [
-    "fontsgeneratorpro.com@2026-02-14"
-   ],
-   "totalUrls": 289
-  },
-  "hackerchoice.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "gridmakerapp.com"
-   ],
-   "placements": [
-    "gridmakerapp.com@2026-07-16",
-    "gridmakerapp.com@2026-07-17",
-    "gridmakerapp.com@2026-07-18",
-    "gridmakerapp.com@2026-07-20",
-    "gridmakerapp.com@2026-07-21",
-    "gridmakerapp.com@2026-07-22",
-    "gridmakerapp.com@2026-07-23"
-   ],
-   "totalUrls": 99
-  },
-  "lovableapp.org": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "gridmakerapp.com"
-   ],
-   "placements": [
-    "gridmakerapp.com@2026-07-27"
-   ],
-   "totalUrls": 3
-  },
-  "fiverr-seo-for-small-businesses.site": {
-   "tier": "spam-net",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": "域名本身写着 seo/ranking/boost/fiverr 的批量站群。出现在自己反链里是被无关方通投，不是成绩。黑名单，不要买。",
-   "observedSites": [
-    "instaplay.ai",
-    "vixal.app"
-   ],
-   "placements": [
-    "instaplay.ai@2026-07-05",
-    "vixal.app@2026-06-25"
-   ],
-   "totalUrls": 20
-  },
-  "grow-your.website": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "instaplay.ai"
-   ],
-   "placements": [
-    "instaplay.ai@2026-07-06",
-    "instaplay.ai@2026-07-07",
-    "instaplay.ai@2026-07-08"
-   ],
-   "totalUrls": 26
-  },
-  "huntscreens.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "instaplay.ai"
-   ],
-   "placements": [
-    "instaplay.ai@2026-07-19"
-   ],
-   "totalUrls": 7
-  },
-  "founderleague.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "instaplay.ai"
-   ],
-   "placements": [
-    "instaplay.ai@2026-07-25"
-   ],
-   "totalUrls": 8
-  },
-  "instaplay.dev": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "instaplay.ai"
-   ],
-   "placements": [
-    "instaplay.ai@2026-07-30"
-   ],
-   "totalUrls": 10
-  },
-  "launches.uicomet.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": "发布板形态，单次投放可产生数百条。",
-   "observedSites": [
-    "invisibletextpro.com",
-    "musiccup.app"
-   ],
-   "placements": [
-    "invisibletextpro.com@2026-02-09",
-    "invisibletextpro.com@2026-02-10",
-    "musiccup.app@2026-07-28",
-    "musiccup.app@2026-07-29"
-   ],
-   "totalUrls": 312
-  },
-  "updf.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "ivycraft.ai"
-   ],
-   "placements": [
-    "ivycraft.ai@2026-05-12"
-   ],
-   "totalUrls": 200
-  },
-  "automateandtweak.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "lightreel.ai"
-   ],
-   "placements": [
-    "lightreel.ai@2026-03-25",
-    "lightreel.ai@2026-03-26",
-    "lightreel.ai@2026-05-12",
-    "lightreel.ai@2026-05-13"
-   ],
-   "totalUrls": 28
-  },
-  "jameslinks.agency": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "lightreel.ai"
-   ],
-   "placements": [
-    "lightreel.ai@2026-05-13"
-   ],
-   "totalUrls": 3
-  },
-  "toplikevideo.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "lightreel.ai"
-   ],
-   "placements": [
-    "lightreel.ai@2026-05-22"
-   ],
-   "totalUrls": 3
-  },
-  "8coint.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "lightreel.ai"
-   ],
-   "placements": [
-    "lightreel.ai@2026-07-05"
-   ],
-   "totalUrls": 3
-  },
-  "free-fonts.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "lingojam.com"
-   ],
-   "placements": [
-    "lingojam.com@2024-07-08",
-    "lingojam.com@2024-07-24"
-   ],
-   "totalUrls": 6
-  },
-  "forum.cosmoteer.net": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "lingojam.com"
-   ],
-   "placements": [
-    "lingojam.com@2024-08-15"
-   ],
-   "totalUrls": 3
-  },
-  "removetexts.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "magicremover.org"
-   ],
-   "placements": [
-    "magicremover.org@2026-04-23"
-   ],
-   "totalUrls": 8
-  },
-  "lukeio.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "screentester.io"
-   ],
-   "placements": [
-    "screentester.io@2026-04-30"
-   ],
-   "totalUrls": 3
-  },
-  "doors101.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "screentester.io"
-   ],
-   "placements": [
-    "screentester.io@2026-06-04"
-   ],
-   "totalUrls": 3
-  },
-  "dietla.pl": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "starting5.app"
-   ],
-   "placements": [
-    "starting5.app@2026-06-04"
-   ],
-   "totalUrls": 4
-  },
-  "gol-behesht.ir": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "starting5.app"
-   ],
-   "placements": [
-    "starting5.app@2026-06-04"
-   ],
-   "totalUrls": 4
-  },
-  "xrp.army": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "starting5.app"
-   ],
-   "placements": [
-    "starting5.app@2026-06-04"
-   ],
-   "totalUrls": 3
-  },
-  "bloody-disgusting.com": {
-   "tier": "not-a-platform",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": "恐怖片媒体站，单站 301 条且分散在连续多天——更像真实报道加全站挂件。",
-   "observedSites": [
-    "subservientghostface.com"
-   ],
-   "placements": [
-    "subservientghostface.com@2026-05-28",
-    "subservientghostface.com@2026-05-29",
-    "subservientghostface.com@2026-05-30",
-    "subservientghostface.com@2026-05-31",
-    "subservientghostface.com@2026-06-01",
-    "subservientghostface.com@2026-06-02",
-    "subservientghostface.com@2026-06-03",
-    "subservientghostface.com@2026-06-04"
-   ],
-   "totalUrls": 301
-  },
-  "twitter.privacidadlibre.org": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "subservientghostface.com"
-   ],
-   "placements": [
-    "subservientghostface.com@2026-05-31"
-   ],
-   "totalUrls": 3
-  },
-  "subservientghostface.wiki": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "subservientghostface.com"
-   ],
-   "placements": [
-    "subservientghostface.com@2026-06-07"
-   ],
-   "totalUrls": 8
-  },
-  "6-9.space": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "subservientghostface.com"
-   ],
-   "placements": [
-    "subservientghostface.com@2026-07-02",
-    "subservientghostface.com@2026-07-04",
-    "subservientghostface.com@2026-07-05"
-   ],
-   "totalUrls": 10
-  },
-  "topai.tools": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "topview.ai"
-   ],
-   "placements": [
-    "topview.ai@2024-04-03",
-    "topview.ai@2024-04-06",
-    "topview.ai@2024-04-09",
-    "topview.ai@2024-04-11"
-   ],
-   "totalUrls": 13
-  },
-  "autoais.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "topview.ai"
-   ],
-   "placements": [
-    "topview.ai@2024-06-07"
-   ],
-   "totalUrls": 4
-  },
-  "aitoolscorner.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "tryonr.com"
-   ],
-   "placements": [
-    "tryonr.com@2025-12-25"
-   ],
-   "totalUrls": 3
-  },
-  "submitaitools.org": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": "有 /submit-your-ai-tool/ 与 Promote 两档，未核价。会生成 /alternatives/<域名> 这类页面，单站可达数百条。",
-   "observedSites": [
-    "tryonr.com"
-   ],
-   "placements": [
-    "tryonr.com@2026-01-03",
-    "tryonr.com@2026-01-04",
-    "tryonr.com@2026-01-05",
-    "tryonr.com@2026-01-07",
-    "tryonr.com@2026-01-08",
-    "tryonr.com@2026-01-10"
-   ],
-   "totalUrls": 273
-  },
-  "startupaideas.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "tryonr.com"
-   ],
-   "placements": [
-    "tryonr.com@2026-01-04",
-    "tryonr.com@2026-01-05",
-    "tryonr.com@2026-01-06"
-   ],
-   "totalUrls": 16
-  },
-  "goodaitools.com": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "tryonr.com"
-   ],
-   "placements": [
-    "tryonr.com@2026-01-04",
-    "tryonr.com@2026-01-05",
-    "tryonr.com@2026-01-07"
-   ],
-   "totalUrls": 39
-  },
-  "soravideo.art": {
-   "tier": "unverified",
-   "price": null,
-   "priceCheckedAt": null,
-   "notes": null,
-   "observedSites": [
-    "tryonr.com"
-   ],
-   "placements": [
-    "tryonr.com@2026-01-08"
-   ],
-   "totalUrls": 3
+  "updatedAt": "2026-08-18",
+  "note": "被观察到用于投放的平台登记表；sitesHit 越高越说明它真的在被使用",
+  "platforms": {
+    "microlaunch.net": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": "/premium 页有价，未核。",
+      "observedSites": [
+        "21st.dev"
+      ],
+      "placements": [
+        "21st.dev@2025-02-19"
+      ],
+      "totalUrls": 5
+    },
+    "aiquerytool.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "21st.dev"
+      ],
+      "placements": [
+        "21st.dev@2025-02-19",
+        "21st.dev@2025-05-13",
+        "21st.dev@2025-05-15"
+      ],
+      "totalUrls": 12
+    },
+    "webcurate.co": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "21st.dev"
+      ],
+      "placements": [
+        "21st.dev@2025-04-08",
+        "21st.dev@2025-04-11"
+      ],
+      "totalUrls": 7
+    },
+    "szxn.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "21st.dev"
+      ],
+      "placements": [
+        "21st.dev@2025-05-01",
+        "21st.dev@2025-05-26",
+        "21st.dev@2025-05-27",
+        "21st.dev@2025-05-30",
+        "21st.dev@2025-06-04",
+        "21st.dev@2025-06-09",
+        "21st.dev@2025-06-12"
+      ],
+      "totalUrls": 25
+    },
+    "sparkbites.dev": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "21st.dev"
+      ],
+      "placements": [
+        "21st.dev@2025-05-19"
+      ],
+      "totalUrls": 3
+    },
+    "adspirer.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "adspirer.ai"
+      ],
+      "placements": [
+        "adspirer.ai@2025-12-21",
+        "adspirer.ai@2025-12-30",
+        "adspirer.ai@2025-12-31",
+        "adspirer.ai@2026-01-08",
+        "adspirer.ai@2026-01-09",
+        "adspirer.ai@2026-01-10",
+        "adspirer.ai@2026-01-19",
+        "adspirer.ai@2026-02-10",
+        "adspirer.ai@2026-03-25",
+        "adspirer.ai@2026-03-31",
+        "adspirer.ai@2026-04-04",
+        "adspirer.ai@2026-04-05",
+        "adspirer.ai@2026-04-10",
+        "adspirer.ai@2026-04-27",
+        "adspirer.ai@2026-04-30",
+        "adspirer.ai@2026-05-02",
+        "adspirer.ai@2026-05-03",
+        "adspirer.ai@2026-05-05",
+        "adspirer.ai@2026-05-06"
+      ],
+      "totalUrls": 159
+    },
+    "developer.adspirer.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "adspirer.ai"
+      ],
+      "placements": [
+        "adspirer.ai@2026-04-24"
+      ],
+      "totalUrls": 11
+    },
+    "prismo.fedibird.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "aiattractivenesstest.ai"
+      ],
+      "placements": [
+        "aiattractivenesstest.ai@2026-04-02"
+      ],
+      "totalUrls": 3
+    },
+    "blogs.dickinson.edu": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "aiattractivenesstest.ai"
+      ],
+      "placements": [
+        "aiattractivenesstest.ai@2026-04-03"
+      ],
+      "totalUrls": 4
+    },
+    "spillhistorie.no": {
+      "tier": "not-a-platform",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": "挪威游戏史站，单站 388 条。同上，先当异常看待而不是渠道。",
+      "observedSites": [
+        "aiattractivenesstest.ai"
+      ],
+      "placements": [
+        "aiattractivenesstest.ai@2026-04-03"
+      ],
+      "totalUrls": 388
+    },
+    "gptdemo.net": {
+      "tier": "link-package",
+      "price": "同上（一份钱覆盖两个域）",
+      "priceCheckedAt": "2026-08-18",
+      "notes": "aitoolhub.net 的姊妹域，见该条。",
+      "observedSites": [
+        "capafy.ai",
+        "eimg.ai",
+        "fontvibe.ai",
+        "imagefree.net"
+      ],
+      "placements": [
+        "capafy.ai@2026-06-02",
+        "eimg.ai@2026-07-18",
+        "eimg.ai@2026-07-19",
+        "fontvibe.ai@2026-04-21",
+        "imagefree.net@2026-03-20",
+        "imagefree.net@2026-03-21"
+      ],
+      "totalUrls": 364
+    },
+    "aitoolhub.net": {
+      "tier": "link-package",
+      "price": "$19.9 一次性",
+      "priceCheckedAt": "2026-08-18",
+      "notes": "与 gptdemo.net 同一运营方（分类计数、版式完全一致）。pricing 页直写「24 High-Quality Dofollow Backlinks」：12 个界面语言 x 2 个域 = 24 个页面。所以「单站 148 条」是一次投放，不是多次。",
+      "observedSites": [
+        "capafy.ai",
+        "eimg.ai",
+        "fontvibe.ai",
+        "imagefree.net"
+      ],
+      "placements": [
+        "capafy.ai@2026-06-02",
+        "eimg.ai@2026-07-18",
+        "fontvibe.ai@2026-04-21",
+        "imagefree.net@2026-03-20",
+        "imagefree.net@2026-03-21"
+      ],
+      "totalUrls": 444
+    },
+    "toolatlas.io": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "capafy.ai",
+        "fontvibe.ai"
+      ],
+      "placements": [
+        "capafy.ai@2026-06-02",
+        "fontvibe.ai@2026-04-20"
+      ],
+      "totalUrls": 11
+    },
+    "mcpservers.org": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "capafy.ai"
+      ],
+      "placements": [
+        "capafy.ai@2026-06-02"
+      ],
+      "totalUrls": 19
+    },
+    "toolify.ai": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "capafy.ai",
+        "fontvibe.ai"
+      ],
+      "placements": [
+        "capafy.ai@2026-06-02",
+        "fontvibe.ai@2026-04-20",
+        "fontvibe.ai@2026-04-21"
+      ],
+      "totalUrls": 16
+    },
+    "seopxl-organic-boost-lab.shop": {
+      "tier": "spam-net",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": "域名本身写着 seo/ranking/boost/fiverr 的批量站群。出现在自己反链里是被无关方通投，不是成绩。黑名单，不要买。",
+      "observedSites": [
+        "cliptica.com",
+        "emojer.org"
+      ],
+      "placements": [
+        "cliptica.com@2026-07-24",
+        "cliptica.com@2026-07-26",
+        "emojer.org@2026-07-24",
+        "emojer.org@2026-07-26"
+      ],
+      "totalUrls": 19
+    },
+    "seo-growth-optimization-hub.shop": {
+      "tier": "spam-net",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": "域名本身写着 seo/ranking/boost/fiverr 的批量站群。出现在自己反链里是被无关方通投，不是成绩。黑名单，不要买。",
+      "observedSites": [
+        "cliptica.com",
+        "emojer.org",
+        "make.design"
+      ],
+      "placements": [
+        "cliptica.com@2026-07-24",
+        "cliptica.com@2026-07-25",
+        "cliptica.com@2026-07-26",
+        "emojer.org@2026-07-26",
+        "make.design@2026-06-08"
+      ],
+      "totalUrls": 17
+    },
+    "seopxl-performance-authority-engine.shop": {
+      "tier": "spam-net",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": "域名本身写着 seo/ranking/boost/fiverr 的批量站群。出现在自己反链里是被无关方通投，不是成绩。黑名单，不要买。",
+      "observedSites": [
+        "cliptica.com",
+        "emojer.org",
+        "make.design"
+      ],
+      "placements": [
+        "cliptica.com@2026-07-24",
+        "cliptica.com@2026-07-26",
+        "emojer.org@2026-07-24",
+        "emojer.org@2026-07-26",
+        "make.design@2026-06-06"
+      ],
+      "totalUrls": 25
+    },
+    "seopxl-traffic-growth-lab.shop": {
+      "tier": "spam-net",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": "域名本身写着 seo/ranking/boost/fiverr 的批量站群。出现在自己反链里是被无关方通投，不是成绩。黑名单，不要买。",
+      "observedSites": [
+        "cliptica.com",
+        "emojer.org"
+      ],
+      "placements": [
+        "cliptica.com@2026-07-24",
+        "emojer.org@2026-07-24"
+      ],
+      "totalUrls": 13
+    },
+    "seo-growth-authority-boost-hub.shop": {
+      "tier": "spam-net",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": "域名本身写着 seo/ranking/boost/fiverr 的批量站群。出现在自己反链里是被无关方通投，不是成绩。黑名单，不要买。",
+      "observedSites": [
+        "cliptica.com",
+        "emojer.org"
+      ],
+      "placements": [
+        "cliptica.com@2026-07-24",
+        "emojer.org@2026-07-24"
+      ],
+      "totalUrls": 16
+    },
+    "seopxl-ranking-boost-lab.shop": {
+      "tier": "spam-net",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": "域名本身写着 seo/ranking/boost/fiverr 的批量站群。出现在自己反链里是被无关方通投，不是成绩。黑名单，不要买。",
+      "observedSites": [
+        "cliptica.com",
+        "emojer.org",
+        "make.design"
+      ],
+      "placements": [
+        "cliptica.com@2026-07-25",
+        "emojer.org@2026-07-24",
+        "emojer.org@2026-07-25",
+        "make.design@2026-06-05",
+        "make.design@2026-06-06"
+      ],
+      "totalUrls": 23
+    },
+    "nano-banana.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "eimg.ai"
+      ],
+      "placements": [
+        "eimg.ai@2026-07-11",
+        "eimg.ai@2026-07-12",
+        "eimg.ai@2026-07-13",
+        "eimg.ai@2026-07-14",
+        "eimg.ai@2026-07-15",
+        "eimg.ai@2026-07-16",
+        "eimg.ai@2026-07-17"
+      ],
+      "totalUrls": 108
+    },
+    "madrimasd.org": {
+      "tier": "not-a-platform",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": "西班牙机构站，单站 254 条集中在一天——形态更像站群注入或全站挂件，不是可投放的平台。别当渠道用。",
+      "observedSites": [
+        "eimg.ai",
+        "magicremover.org"
+      ],
+      "placements": [
+        "eimg.ai@2026-07-13",
+        "magicremover.org@2026-04-23",
+        "magicremover.org@2026-04-24"
+      ],
+      "totalUrls": 292
+    },
+    "aegypten-ausflug.de": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "eimg.ai"
+      ],
+      "placements": [
+        "eimg.ai@2026-07-13"
+      ],
+      "totalUrls": 5
+    },
+    "heroacademiabeyond.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "eimg.ai"
+      ],
+      "placements": [
+        "eimg.ai@2026-07-15"
+      ],
+      "totalUrls": 3
+    },
+    "creati.ai": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "eimg.ai"
+      ],
+      "placements": [
+        "eimg.ai@2026-07-18",
+        "eimg.ai@2026-07-19"
+      ],
+      "totalUrls": 12
+    },
+    "launchitx.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "eimg.ai"
+      ],
+      "placements": [
+        "eimg.ai@2026-07-18",
+        "eimg.ai@2026-07-19"
+      ],
+      "totalUrls": 26
+    },
+    "bestfor.ai": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "eimg.ai"
+      ],
+      "placements": [
+        "eimg.ai@2026-07-18"
+      ],
+      "totalUrls": 3
+    },
+    "showmebest.ai": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "eimg.ai"
+      ],
+      "placements": [
+        "eimg.ai@2026-07-18"
+      ],
+      "totalUrls": 6
+    },
+    "bai.tools": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "eimg.ai"
+      ],
+      "placements": [
+        "eimg.ai@2026-07-18",
+        "eimg.ai@2026-07-19"
+      ],
+      "totalUrls": 8
+    },
+    "mossai.org": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "eimg.ai",
+        "tryonr.com"
+      ],
+      "placements": [
+        "eimg.ai@2026-07-18",
+        "eimg.ai@2026-07-19",
+        "tryonr.com@2025-12-17",
+        "tryonr.com@2025-12-18",
+        "tryonr.com@2025-12-21",
+        "tryonr.com@2025-12-22",
+        "tryonr.com@2025-12-26",
+        "tryonr.com@2025-12-27",
+        "tryonr.com@2025-12-28",
+        "tryonr.com@2025-12-29",
+        "tryonr.com@2025-12-30",
+        "tryonr.com@2025-12-31",
+        "tryonr.com@2026-01-01",
+        "tryonr.com@2026-01-04",
+        "tryonr.com@2026-01-05",
+        "tryonr.com@2026-01-06",
+        "tryonr.com@2026-01-07",
+        "tryonr.com@2026-01-08",
+        "tryonr.com@2026-01-09",
+        "tryonr.com@2026-01-10"
+      ],
+      "totalUrls": 94
+    },
+    "iuu.ai": {
+      "tier": "free-with-account",
+      "price": "$0（但要注册）",
+      "priceCheckedAt": "2026-08-18",
+      "notes": "FAQ 白纸黑字写 fee is currently $0，但提交按钮本身就是 Login。「免费」与「免注册」是两件事。",
+      "observedSites": [
+        "eimg.ai"
+      ],
+      "placements": [
+        "eimg.ai@2026-07-18",
+        "eimg.ai@2026-07-19"
+      ],
+      "totalUrls": 8
+    },
+    "ai.keenchase.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "eimg.ai"
+      ],
+      "placements": [
+        "eimg.ai@2026-07-18"
+      ],
+      "totalUrls": 4
+    },
+    "aistage.net": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "eimg.ai"
+      ],
+      "placements": [
+        "eimg.ai@2026-07-19"
+      ],
+      "totalUrls": 3
+    },
+    "www3.wind.ne.jp": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "eimg.ai"
+      ],
+      "placements": [
+        "eimg.ai@2026-07-19"
+      ],
+      "totalUrls": 3
+    },
+    "emojer.ru": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "emojer.org"
+      ],
+      "placements": [
+        "emojer.org@2026-07-16",
+        "emojer.org@2026-08-01"
+      ],
+      "totalUrls": 7
+    },
+    "cqiar.blogspot.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "fancytextguru.com"
+      ],
+      "placements": [
+        "fancytextguru.com@2024-01-14"
+      ],
+      "totalUrls": 3
+    },
+    "the-bulldog.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "fancytextguru.com",
+        "textfx.co"
+      ],
+      "placements": [
+        "fancytextguru.com@2024-08-12",
+        "textfx.co@2025-04-18"
+      ],
+      "totalUrls": 10
+    },
+    "saashunt.best": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": "有 Submit Project 与 Pricing，首页自述「Submit, Earn a Badge, High DR Backlink」。",
+      "observedSites": [
+        "fontsgeneratorpro.com"
+      ],
+      "placements": [
+        "fontsgeneratorpro.com@2026-02-14"
+      ],
+      "totalUrls": 289
+    },
+    "hackerchoice.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "gridmakerapp.com"
+      ],
+      "placements": [
+        "gridmakerapp.com@2026-07-16",
+        "gridmakerapp.com@2026-07-17",
+        "gridmakerapp.com@2026-07-18",
+        "gridmakerapp.com@2026-07-20",
+        "gridmakerapp.com@2026-07-21",
+        "gridmakerapp.com@2026-07-22",
+        "gridmakerapp.com@2026-07-23"
+      ],
+      "totalUrls": 99
+    },
+    "lovableapp.org": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "gridmakerapp.com"
+      ],
+      "placements": [
+        "gridmakerapp.com@2026-07-27"
+      ],
+      "totalUrls": 3
+    },
+    "fiverr-seo-for-small-businesses.site": {
+      "tier": "spam-net",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": "域名本身写着 seo/ranking/boost/fiverr 的批量站群。出现在自己反链里是被无关方通投，不是成绩。黑名单，不要买。",
+      "observedSites": [
+        "instaplay.ai",
+        "vixal.app"
+      ],
+      "placements": [
+        "instaplay.ai@2026-07-05",
+        "vixal.app@2026-06-25"
+      ],
+      "totalUrls": 20
+    },
+    "grow-your.website": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "instaplay.ai"
+      ],
+      "placements": [
+        "instaplay.ai@2026-07-06",
+        "instaplay.ai@2026-07-07",
+        "instaplay.ai@2026-07-08"
+      ],
+      "totalUrls": 26
+    },
+    "huntscreens.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "instaplay.ai"
+      ],
+      "placements": [
+        "instaplay.ai@2026-07-19"
+      ],
+      "totalUrls": 7
+    },
+    "founderleague.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "instaplay.ai"
+      ],
+      "placements": [
+        "instaplay.ai@2026-07-25"
+      ],
+      "totalUrls": 8
+    },
+    "instaplay.dev": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "instaplay.ai"
+      ],
+      "placements": [
+        "instaplay.ai@2026-07-30"
+      ],
+      "totalUrls": 10
+    },
+    "launches.uicomet.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": "发布板形态，单次投放可产生数百条。",
+      "observedSites": [
+        "invisibletextpro.com",
+        "musiccup.app"
+      ],
+      "placements": [
+        "invisibletextpro.com@2026-02-09",
+        "invisibletextpro.com@2026-02-10",
+        "musiccup.app@2026-07-28",
+        "musiccup.app@2026-07-29"
+      ],
+      "totalUrls": 312
+    },
+    "updf.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "ivycraft.ai"
+      ],
+      "placements": [
+        "ivycraft.ai@2026-05-12"
+      ],
+      "totalUrls": 200
+    },
+    "automateandtweak.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "lightreel.ai"
+      ],
+      "placements": [
+        "lightreel.ai@2026-03-25",
+        "lightreel.ai@2026-03-26",
+        "lightreel.ai@2026-05-12",
+        "lightreel.ai@2026-05-13"
+      ],
+      "totalUrls": 28
+    },
+    "jameslinks.agency": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "lightreel.ai"
+      ],
+      "placements": [
+        "lightreel.ai@2026-05-13"
+      ],
+      "totalUrls": 3
+    },
+    "toplikevideo.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "lightreel.ai"
+      ],
+      "placements": [
+        "lightreel.ai@2026-05-22"
+      ],
+      "totalUrls": 3
+    },
+    "8coint.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "lightreel.ai"
+      ],
+      "placements": [
+        "lightreel.ai@2026-07-05"
+      ],
+      "totalUrls": 3
+    },
+    "free-fonts.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "lingojam.com"
+      ],
+      "placements": [
+        "lingojam.com@2024-07-08",
+        "lingojam.com@2024-07-24"
+      ],
+      "totalUrls": 6
+    },
+    "forum.cosmoteer.net": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "lingojam.com"
+      ],
+      "placements": [
+        "lingojam.com@2024-08-15"
+      ],
+      "totalUrls": 3
+    },
+    "removetexts.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "magicremover.org"
+      ],
+      "placements": [
+        "magicremover.org@2026-04-23"
+      ],
+      "totalUrls": 8
+    },
+    "lukeio.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "screentester.io"
+      ],
+      "placements": [
+        "screentester.io@2026-04-30"
+      ],
+      "totalUrls": 3
+    },
+    "doors101.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "screentester.io"
+      ],
+      "placements": [
+        "screentester.io@2026-06-04"
+      ],
+      "totalUrls": 3
+    },
+    "dietla.pl": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "starting5.app"
+      ],
+      "placements": [
+        "starting5.app@2026-06-04"
+      ],
+      "totalUrls": 4
+    },
+    "gol-behesht.ir": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "starting5.app"
+      ],
+      "placements": [
+        "starting5.app@2026-06-04"
+      ],
+      "totalUrls": 4
+    },
+    "xrp.army": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "starting5.app"
+      ],
+      "placements": [
+        "starting5.app@2026-06-04"
+      ],
+      "totalUrls": 3
+    },
+    "bloody-disgusting.com": {
+      "tier": "not-a-platform",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": "恐怖片媒体站，单站 301 条且分散在连续多天——更像真实报道加全站挂件。",
+      "observedSites": [
+        "subservientghostface.com"
+      ],
+      "placements": [
+        "subservientghostface.com@2026-05-28",
+        "subservientghostface.com@2026-05-29",
+        "subservientghostface.com@2026-05-30",
+        "subservientghostface.com@2026-05-31",
+        "subservientghostface.com@2026-06-01",
+        "subservientghostface.com@2026-06-02",
+        "subservientghostface.com@2026-06-03",
+        "subservientghostface.com@2026-06-04"
+      ],
+      "totalUrls": 301
+    },
+    "twitter.privacidadlibre.org": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "subservientghostface.com"
+      ],
+      "placements": [
+        "subservientghostface.com@2026-05-31"
+      ],
+      "totalUrls": 3
+    },
+    "subservientghostface.wiki": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "subservientghostface.com"
+      ],
+      "placements": [
+        "subservientghostface.com@2026-06-07"
+      ],
+      "totalUrls": 8
+    },
+    "6-9.space": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "subservientghostface.com"
+      ],
+      "placements": [
+        "subservientghostface.com@2026-07-02",
+        "subservientghostface.com@2026-07-04",
+        "subservientghostface.com@2026-07-05"
+      ],
+      "totalUrls": 10
+    },
+    "topai.tools": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "topview.ai"
+      ],
+      "placements": [
+        "topview.ai@2024-04-03",
+        "topview.ai@2024-04-06",
+        "topview.ai@2024-04-09",
+        "topview.ai@2024-04-11"
+      ],
+      "totalUrls": 13
+    },
+    "autoais.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "topview.ai"
+      ],
+      "placements": [
+        "topview.ai@2024-06-07"
+      ],
+      "totalUrls": 4
+    },
+    "aitoolscorner.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "tryonr.com"
+      ],
+      "placements": [
+        "tryonr.com@2025-12-25"
+      ],
+      "totalUrls": 3
+    },
+    "submitaitools.org": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": "有 /submit-your-ai-tool/ 与 Promote 两档，未核价。会生成 /alternatives/<域名> 这类页面，单站可达数百条。",
+      "observedSites": [
+        "tryonr.com"
+      ],
+      "placements": [
+        "tryonr.com@2026-01-03",
+        "tryonr.com@2026-01-04",
+        "tryonr.com@2026-01-05",
+        "tryonr.com@2026-01-07",
+        "tryonr.com@2026-01-08",
+        "tryonr.com@2026-01-10"
+      ],
+      "totalUrls": 273
+    },
+    "startupaideas.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "tryonr.com"
+      ],
+      "placements": [
+        "tryonr.com@2026-01-04",
+        "tryonr.com@2026-01-05",
+        "tryonr.com@2026-01-06"
+      ],
+      "totalUrls": 16
+    },
+    "goodaitools.com": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "tryonr.com"
+      ],
+      "placements": [
+        "tryonr.com@2026-01-04",
+        "tryonr.com@2026-01-05",
+        "tryonr.com@2026-01-07"
+      ],
+      "totalUrls": 39
+    },
+    "soravideo.art": {
+      "tier": "unverified",
+      "price": null,
+      "priceCheckedAt": null,
+      "notes": null,
+      "observedSites": [
+        "tryonr.com"
+      ],
+      "placements": [
+        "tryonr.com@2026-01-08"
+      ],
+      "totalUrls": 3
+    },
+    "submitdirs.com": {
+      "tier": "link-package",
+      "price": "PRO $249（促销码 EARLY199 后 $199）",
+      "priceCheckedAt": "2026-08-18",
+      "notes": "代投目录包，一次下单铺 20+ 个目录，实测批次里多数是低 DA / link-farm 型目录（SourceForge、Viesearch、Entireweb、ExactSeek、SoMuch、cipinet、iuu.ai 等），且批次内夹带多个加价项。第二笔订单被商家以「no suitable directory list」全额退款——说明它对不吃目录的站点没有货。证据来自第三方公开 Skill gr-backlinks 自己的开销台账，不是本项目的观察。",
+      "observedSites": [
+        "analook.com",
+        "gingiris.tools"
+      ],
+      "placements": [
+        "analook.com@2026-06-17",
+        "gingiris.tools@2026-06-18"
+      ],
+      "totalUrls": 0
+    },
+    "submitsaas.com": {
+      "tier": "link-package",
+      "price": "$140",
+      "priceCheckedAt": "2026-08-18",
+      "notes": "同类代投目录包。买方自己在台账里备注「需核对实拿几条 do-follow」——即交付时并未给出可验证的 rel 清单。证据同样来自第三方公开 Skill gr-backlinks 的开销台账。",
+      "observedSites": [
+        "analook.com"
+      ],
+      "placements": [
+        "analook.com@2026-06-20"
+      ],
+      "totalUrls": 0
+    }
   }
- }
 }

--- a/backlink/data/schema/index-submission.schema.json
+++ b/backlink/data/schema/index-submission.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/yan-labs/yan-skills/backlink/data/schema/index-submission.schema.json",
+  "title": "Index submission channels",
+  "description": "Search engines that accept a URL for indexing but publish no link. These are NOT placement channels and must never be merged into free-channels.json: nothing here produces a backlink, so anchorRendered and relObserved are meaningless. The file exists because the verify stage of this Skill has to name which index it checked, and because an engine outside the IndexNow membership gets nothing from the usual automated push.",
+  "type": "object",
+  "required": ["version", "updatedAt", "engines"],
+  "properties": {
+    "version": { "type": "integer", "minimum": 1 },
+    "updatedAt": { "type": "string", "format": "date-time" },
+    "engines": { "type": "array", "items": { "$ref": "#/$defs/engine" } }
+  },
+  "$defs": {
+    "engine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id", "name", "submitUrl", "independentIndex", "indexNowMember",
+        "account", "captcha", "batch", "status", "lastVerifiedAt", "evidence"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$",
+          "description": "Stable slug, also the qualifier used when writing indexed@<id> in a ledger entry."
+        },
+        "name": { "type": "string", "minLength": 2 },
+        "submitUrl": { "type": "string", "format": "uri" },
+        "independentIndex": {
+          "type": "boolean",
+          "description": "True only when the engine crawls the web itself. An engine that resells another index needs no separate submission, and recording one as independent invents work that does nothing."
+        },
+        "indexNowMember": {
+          "type": "boolean",
+          "description": "Whether an IndexNow push already reaches it. False is the whole reason a record belongs here: automated pushes miss it, so the URLs have to be handed over by hand."
+        },
+        "webmasterConsole": { "type": "boolean", "description": "Whether a verified-owner console exists at all. Absent means no coverage report, so index counts can only be estimated with a site: query." },
+        "sitemapAccepted": { "type": "boolean", "description": "Whether a sitemap can be handed over instead of individual URLs." },
+        "account": { "enum": ["none", "required", "optional"] },
+        "captcha": {
+          "enum": ["none", "passive", "interactive", "unknown"],
+          "description": "passive = clears itself in an ordinary browser with no user action. interactive = a real challenge; those are rejected, never solved."
+        },
+        "browserRequired": { "type": "boolean" },
+        "batch": {
+          "type": "boolean",
+          "description": "Whether more than one URL can go in per submission. False means the cost of a site-wide submission is linear in page count — say so before starting."
+        },
+        "ratePolicy": { "type": ["string", "null"], "description": "Any stated or observed limit on submissions per period. null when nothing was stated and nothing was hit." },
+        "aiGrounding": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["claimed", "source", "what"],
+          "description": "Why this index matters beyond its own result page. Keep it to what the operator publishes about itself, with the URL that says so — this field is the GEO argument and it must not become folklore about which assistant uses which index.",
+          "properties": {
+            "claimed": { "type": "boolean" },
+            "source": { "type": "string", "format": "uri" },
+            "what": { "type": "string", "minLength": 20 }
+          }
+        },
+        "howToSubmit": { "type": "string" },
+        "traps": { "type": "array", "items": { "type": "string" } },
+        "status": { "enum": ["live", "changed", "dead", "rejected", "unverified"] },
+        "rejectReason": { "type": "string" },
+        "lastVerifiedAt": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+        "evidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["method", "what"],
+          "properties": {
+            "method": { "enum": ["browser-dom", "anonymous-http", "both"] },
+            "what": {
+              "type": "string",
+              "minLength": 10,
+              "description": "What the confirmation actually said and how many URLs were individually re-read. A campaign where most submissions were not re-read must say so here rather than rounding up."
+            },
+            "publicUrl": { "type": ["string", "null"] }
+          }
+        },
+        "notes": { "type": "string" }
+      }
+    }
+  }
+}

--- a/backlink/references/index-submission.md
+++ b/backlink/references/index-submission.md
@@ -1,0 +1,94 @@
+# Index submission — the channels that publish no link
+
+**Nothing in this reference produces a backlink.** An index-submission channel
+hands a URL to a search engine and gets nothing back but a confirmation string.
+It is in this Skill for two reasons, and neither of them is placement:
+
+1. **The verify stage was under-specified.** The state machine ends at
+   `indexed`, and it never said *whose* index. Every promotion to `indexed` in
+   practice came from Search Console or a Google/Bing `site:` query — one
+   family of crawlers standing in for "the web".
+2. **An engine outside IndexNow gets nothing from the automated push.** The
+   usual "ping IndexNow after deploy" wiring reaches Bing, Yandex, Seznam and
+   Naver. An engine with its own crawler and no IndexNow membership is simply
+   not in that list, and no amount of deploying moves it.
+
+Records live in [`data/index-submission.json`](../data/index-submission.json),
+validated by the same `scripts/validate-data.mjs` gate as everything else.
+
+## Do not merge this into `free-channels.json`
+
+That file's contract is *a place that publishes a link*: every row must answer
+`anchorRendered` and, when checked, `relObserved`. Those two questions are
+meaningless here — there is no anchor, because there is no page. A submission
+form filed as a channel would read, to anyone querying the data later, as one
+more place we got a link. The Skill's standing rule already covers it: **do not
+record a submission as a backlink.** This file is how that rule survives contact
+with a genuinely useful channel that happens not to be one.
+
+## Why this is a GEO channel, stated precisely
+
+The reason to care about a second index is not its own result page — for most
+engines here that traffic is a rounding error. It is that **an independent index
+is a grounding source for AI answers**, and a page missing from the index is
+missing from every answer built on it.
+
+Keep this argument tied to what the operator publishes about itself. Brave's own
+API page is explicit that the index is not a scraper over Google or Bing but its
+own, and sells it for grounding chatbots and AI search — that is a citable
+claim with a URL behind it, which is why the schema requires `aiGrounding.source`.
+What must **not** go in: "assistant X uses index Y". Those pairings change
+quietly, are rarely confirmed by either party, and turn the field into folklore.
+
+## The measurement that justifies the work
+
+Before submitting anything, get the baseline, because without it the campaign
+can never be judged:
+
+```
+site:<domain>  on the target engine   →  how many pages it already has
+Search Console / Bing coverage        →  how many pages Google/Bing have
+```
+
+A wide gap is the signal. On the one site measured so far the gap was **1 versus
+37 of 38** — not a crawl-delay story, an entire engine we had never touched.
+
+Then **recheck after**, and record the outcome either way. A submission channel
+that moves nothing is a finding worth as much as one that works; without the
+recheck this is 38 manual operations justified by a hunch.
+
+## Writing it down afterwards
+
+Qualify every index claim with the engine: `indexed@google`, `indexed@brave`.
+The `id` in the data file is the qualifier. An unqualified "indexed" is a claim
+about the whole web made from one crawler's opinion.
+
+Do not retroactively rewrite old ledger entries — the cost exceeds the value and
+the reading is recoverable from the evidence note. Qualify new ones.
+
+## Per-engine mechanics
+
+Read the `traps` array on each record before automating anything. The Brave form
+is documented there in full; the shape of its traps generalises past it:
+
+- **A synthesised `click()` may not submit.** A passive human check can require
+  a trusted event. Injecting the field value programmatically is usually fine —
+  it is the click that has to be real. This is not CAPTCHA bypass and must never
+  become it: the check runs normally and clears itself, or the channel is
+  rejected.
+- **Enter is not a submit button.** Verify, do not assume.
+- **A passive check takes seconds.** Navigating away during it discards the
+  submission with no error. Wait for the confirmation text.
+- **Success may disable the form permanently.** One URL per page load.
+- **Our own network log is not the judge.** After an in-page reload, request
+  logging can stop recording while submissions keep succeeding. The judge is the
+  target's own confirmation string — the same rule that governs the placement
+  workflows.
+
+## What is not in here yet
+
+Only engines that were actually operated get a record. Other independent indexes
+exist — Brave's own result page offers Mojeek alongside Google and Bing — but
+**whether they have a submission endpoint at all is unchecked**, and an
+unverified row is worth less than an absent one. Check one, operate it, then add
+it.

--- a/backlink/references/instant-publish.md
+++ b/backlink/references/instant-publish.md
@@ -581,3 +581,67 @@ being honoured — search for something only the target domain could match —
 before reading anything into the result. Failing that, report the page's own
 `robots` directive as what it is (a claim of indexability) and leave actual
 indexation unverified. It takes days to become true anyway.
+
+## Reading a third-party "places to get a backlink" list
+
+These lists circulate widely — tiered tables of 200-300 named platforms with DR,
+a **Dofollow** column, and a Cost column. They are worth harvesting and worthless
+to trust. One such list (270 entries, 13 tiers) was verified against reality in
+2026-08; what came back is the general shape to expect.
+
+**The Dofollow column is an assertion about the platform, not an observation of a
+link.** The list marked free press-release sites as dofollow. The one that was
+actually sampled publishes the author's URLs as **plain text nodes and emits no
+anchor at all** — see the `openpr` record in `data/free-channels.json`. A column
+in someone's table is never evidence; only a rendered anchor on a live item is.
+
+**Names, not URLs.** These lists overwhelmingly give a brand name with no domain.
+Resolving 200 names to domains is most of the work, and a name that resolves to a
+live site tells you nothing about whether the *original* site is still there.
+
+**Expect the long tail to be resold, not merely stale.** In the 2026-08 sweep the
+one domain that turned out to be dead was dead in the strongest sense: it answers
+HTTP 200 and **redirects to an unrelated crypto product**. A status-code check
+passes it. Only following the redirect, or reading the title, catches it.
+
+### The sitewide-advertiser false positive
+
+On a UGC page, an outbound anchor with **no `rel`** looks exactly like a followable
+author link, and it is the single easiest way to record a channel as usable when it
+is not. The free-press-release site above carries several no-`rel` outbound anchors
+— all of them the platform's own properties, a consent manager, and one advertiser.
+
+**The test is cheap: open a second, unrelated item on the same platform.** Any
+outbound domain that appears on both is furniture, not an author link. Only a
+domain unique to one item can be that item's author link. Do this before recording
+`anchorRendered: true` on any platform you have sampled exactly once.
+
+### What the tiers are actually made of
+
+Two structural facts decide how much of such a list you can act on at all:
+
+- **The profile/content-platform tier is a registration tier.** Of 20 sampled,
+  17 required a free account before publishing anything. Account creation is not
+  an agent action — that tier converts into an owner to-do list, not work you can
+  schedule. Budget it as human hours, not as automation.
+- **Roughly a quarter of any such list will refuse plain HTTP** (403 or a reset).
+  None of those are evidence of death. See the asymmetry rule below.
+
+### Request headers are a bot fingerprint, not just a User-Agent
+
+A browser-shaped `User-Agent` alone still gets refused. Adding the two headers a
+real browser always sends —
+
+```
+accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+accept-language: en-US,en;q=0.9
+```
+
+— converted several hard connection failures into clean 200s in the same sweep,
+with no other change. A request carrying a Chrome UA and no `Accept` header is a
+recognisable non-browser signature.
+
+This matters beyond politeness: without those headers the sweep produced a list of
+"dead" sites that were merely defended, and acting on it would have discarded live
+channels. Set them on every probe, then treat a remaining 403 as **unknown** —
+still never as dead.

--- a/backlink/scripts/validate-data.mjs
+++ b/backlink/scripts/validate-data.mjs
@@ -78,6 +78,49 @@ for (const c of free.channels) {
   }
 }
 
+// —— index-submission ————————————————————————————————————————
+// **这张表里没有一条外链。** 它记的是「把 URL 交给谁去收录」，
+// 和 free-channels 是两类东西，混进去会直接毁掉那张表的语义
+// （那边每条都要回答 anchorRendered / relObserved，这边这两个字段根本不存在）。
+// 它之所以属于本 Skill：verify 阶段的 `indexed` 一直没说清是**谁的** index，
+// 而不在 IndexNow 成员里的引擎，我们那套自动推送一条都没送到。
+const idx = JSON.parse(await readFile(join(DATA, 'index-submission.json'), 'utf8'));
+const idxSeen = new Set();
+for (const e of idx.engines || []) {
+  const at = `index-submission[${e.id || '?'}]`;
+  if (!e.id || !/^[a-z0-9][a-z0-9-]*$/.test(e.id)) err(at, 'id 缺失或不是小写短横线 slug');
+  if (idxSeen.has(e.id)) err(at, 'id 重复');
+  idxSeen.add(e.id);
+  if (!STATUS.has(e.status)) err(at, `status 非法：${e.status}`);
+  if (!CAPTCHA.has(e.captcha)) err(at, `captcha 非法：${e.captcha}`);
+  if (typeof e.independentIndex !== 'boolean') err(at, 'independentIndex 必填');
+  if (typeof e.indexNowMember !== 'boolean') err(at, 'indexNowMember 必填');
+  if (typeof e.batch !== 'boolean') err(at, 'batch 必填');
+  if (!isDate(e.lastVerifiedAt)) err(at, 'lastVerifiedAt 必须是 YYYY-MM-DD');
+  if (!e.evidence || !METHOD.has(e.evidence.method)) err(at, 'evidence.method 必须是 browser-dom / anonymous-http / both');
+  if (!e.evidence?.what || e.evidence.what.length < 10) err(at, 'evidence.what 太短：写清楚确认文案说了什么、以及有几条是逐条复读过的');
+
+  // —— 语义层 ————————————————————————————————————————————
+  // 手工提交的**唯一**理由是「自动推送送不到」。两个都为真的记录是在凭空造工作量。
+  if (e.indexNowMember === true && e.independentIndex === false) {
+    err(at, 'indexNowMember=true 且 independentIndex=false —— 这种引擎既被自动推送覆盖、又没有自己的索引，手工提交毫无意义，不该收进这张表');
+  }
+  // GEO 论据最容易退化成传闻（「某某助手用的是它」）。只收运营方自己publish的说法 + 出处。
+  if (e.aiGrounding && (e.aiGrounding.claimed !== true || !/^https?:\/\//.test(e.aiGrounding.source || ''))) {
+    err(at, 'aiGrounding 必须带 claimed=true 和一个 http(s) 出处 —— 这一格是 GEO 论据，没有出处就是传闻');
+  }
+  if (e.captcha === 'interactive' && e.status === 'live') {
+    err(at, 'captcha=interactive 不能标 live —— 需要人解题的挑战一律记为拒绝，本 Skill 不绕验证码');
+  }
+  if (e.status === 'rejected' && !e.rejectReason) err(at, 'status=rejected 必须写 rejectReason');
+  if (e.batch === false && !e.howToSubmit) {
+    warn(at, 'batch=false 却没写 howToSubmit —— 逐条提交的成本随页数线性增长，动手前必须能算出这个数');
+  }
+  if (e.status === 'live' && isDate(e.lastVerifiedAt) && daysAgo(e.lastVerifiedAt) > 180) {
+    warn(at, `标为 live 但已 ${daysAgo(e.lastVerifiedAt)} 天未复验`);
+  }
+}
+
 // —— paid-platforms ————————————————————————————————————————————
 const paid = JSON.parse(await readFile(join(DATA, 'paid-platforms.json'), 'utf8'));
 const TIER = new Set(['paid-listing', 'link-package', 'free-with-account', 'spam-net', 'not-a-platform', 'unverified']);
@@ -93,6 +136,7 @@ for (const [host, p] of Object.entries(paid.platforms || {})) {
 if (!quiet || errors.length) {
   process.stdout.write(`free-channels: ${free.channels.length} 条（live ${free.channels.filter((c) => c.status === 'live').length}）\n`);
   process.stdout.write(`paid-platforms: ${Object.keys(paid.platforms || {}).length} 条\n`);
+  process.stdout.write(`index-submission: ${(idx.engines || []).length} 条（收录提交口，**不是外链**）\n`);
   for (const w of warns) process.stdout.write(`  ⚠ ${w}\n`);
 }
 if (errors.length) {


### PR DESCRIPTION
## 为什么不是往 free-channels 里加一行

Brave 的 `submit-url` **不产生任何链接**。`free-channels.json` 的契约是「一个会发布链接的地方」，每条都要回答 `anchorRendered` / `relObserved`，这两个字段在收录提交口上没有意义。混进去 = 把提交记成外链，正是 SKILL.md 里那条硬规则禁止的。

## 但它暴露了 Skill 自己的一个洞

状态机末端的 `indexed` **从来没说清是「谁的」index**。回看实际用法，所有 `indexed` 证据都来自 GSC 或 Google/Bing 的 `site:` 查询——一族爬虫代表了「网」。

而不在 IndexNow 成员里的引擎（成员是 Bing / Yandex / Seznam / Naver），「部署后自动推 IndexNow」那套一条都送不到。实测一个站：

| | 收录 |
|---|---|
| GSC | 37 / 38 |
| Brave `site:` | **1** |

## 改动

- **`data/index-submission.json`** + schema + `validate-data.mjs` 校验段。两条语义门禁（都跑过反例验证会失败）：
  - `indexNowMember=true` 且 `independentIndex=false` → 判错。这种引擎既被自动推送覆盖又没有自己的索引，手工提交是凭空造工作量。
  - `aiGrounding` 必须带 `claimed=true` 和 http(s) 出处 → 防止 GEO 论据退化成「某某助手用的是它」这类传闻。
- **`references/index-submission.md`** — GEO 论据的正确说法（独立索引是 AI 回答的 grounding 源，缺页即缺席；出处限定为运营方自己发布的说法）、先量基线再复查的判据、以及 Brave 表单的坑。
- **SKILL.md** — 路由行、Verify 段加「`indexed` 必须写 `indexed@google` / `indexed@brave`」、硬规则那条补上「把 URL 交给搜索引擎也算提交，不算外链」。老记录不回溯改写，新记录必须带限定。
- **CONTRIBUTING.md** — 数据模型从两张表改成三张，写清楚字段为什么这么设。

## 一个可能被误读的点

reference 里记了「合成的 `click()` 不触发提交，因为无感人机验证认 `isTrusted`」。这是**记录机制，不是绕过**——验证照跑照过，过不了就判 `rejected`。`captcha=interactive` 仍然不允许标 `live`。

## 证据口径

38 条提交，**逐条复读确认的是 12 条**，其余 26 条走相同流程但未逐条复核。schema 的 `evidence.what` 现在明确要求写出这个比例，不许四舍五入成「全部确认」。

Brave 的收录会不会因此变化**未知**，reference 里写死了必须复查并如实记录结果——没动也是有价值的结论。

## 门禁

- `node scripts/validate-data.mjs` → 通过（21 free / 73 paid / 1 index-submission）
- `node --test tests/*.mjs` → 12 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)