### PR TITLE
fix: stop two Trends queries from sharing one tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npx skills add yan-labs/yan-skills -g --all
 
 ## `rankup` — 网站全生命周期总控
 
-版本 `2.60.0`。它不重复实现 Wrangler、Stripe 或趋势工具，它负责把这些能力串成一条长期可维护的工作流，并且记住你在每个项目上做过什么。小游戏站另有一条从新词监控、iframe 供给、可玩页面、广告到持续迭代的[专用链路](rankup/references/game-sites.md)。
+版本 `2.60.1`。它不重复实现 Wrangler、Stripe 或趋势工具，它负责把这些能力串成一条长期可维护的工作流，并且记住你在每个项目上做过什么。小游戏站另有一条从新词监控、iframe 供给、可玩页面、广告到持续迭代的[专用链路](rankup/references/game-sites.md)。
 
 登录态数据平台可以直接走薄 CLI，把一次探路沉淀成可续跑清单：
 

--- a/rankup/SKILL.md
+++ b/rankup/SKILL.md
@@ -2,7 +2,7 @@
 name: rankup
 description: 网站从零到一与长期增长的总控 Skill。用于新建网站、SaaS、工具站或内容站，规划或初始化 TanStack Start Monorepo，使用 Cloudflare Workers、D1、R2 部署全栈应用，接入支付，执行 SEO、内容、外链、上线验证和持续迭代；也负责 Google Trends 查询、关键词难度（KD）估算与选词工作流；2026 AI 搜索范式（AI Overviews、AI Mode、Preferred Sources、Discover 独立算法、Information Gain、引用优先于排名）；AI Agent 就绪度评分（is-agentic、agent readiness、llms.txt、MCP 可发现性、AI 代理优化）。用户提到 rankup、rankup init、rankup check、环节闸门、检查清单、checklist、"现在该做什么"、"到哪一步了"、"这个环节能不能过"、"本轮还差什么"、建站、网站改版、搜索流量、GSC、排名、关键词、CTR、索引、网站增长，或提到 谷歌趋势、Google Trends、搜索热度、热度对比、搜索趋势、trending、"XX 和 YY 哪个更火"、"今天美国/日本在搜什么"、每日热搜、"这个词能不能做站"、"哪个市场/国家有机会"、帮我选 SEO 关键词、选词、选品调研、市场探测、挖需求、找需求、需求挖掘、找方向、找选题、"最近有什么能做的"、"找几个关键词"、"挖个新词的工具站"、"看看有什么游戏站能做"、竞品调研、榜单调研、差评挖掘、反查谁在赚钱、关键词难度、KD、竞争度、SERP 分析、"这个词难不难做"、"做这个词要多少外链"，或提到 哥飞、web.cafe、哥飞论坛、哥飞的朋友们、悬赏、悬赏问答、经验帖、"群里怎么说的"、"社群里有没有讲过"、"论坛里搜一下"、"哥飞说过什么"、哥飞.ai，或提到 AI 搜索优化、AI Overviews、AI Mode、被 AI 引用、AEO、GEO、Preferred Sources、Discover 优化、Google 算法更新、核心更新、spam 更新、Information Gain，或提到 AI Agent 就绪度、is-agentic、agent readiness、llms.txt、对 AI 代理友好、AI 代理优化、agent-friendly、agentic score 时使用。
 metadata:
-  version: "2.60.0"
+  version: "2.60.1"
 ---
 
 # Rankup 2.0

--- a/rankup/references/trends.md
+++ b/rankup/references/trends.md
@@ -133,7 +133,15 @@ python3 $GT compare "keyword" --geo JP --time 7d --keep-session
 python3 $GT close
 ```
 
-单条查询默认仍会在结束后关闭会话；`--session NAME` 可为并行任务指定独立会话名。
+单条查询默认跑完即释放会话。**`--keep-session` 之后一定要记得 `close`**——
+它留下的标签页会一直停在空白的 explore 界面上（取数全在页面内 fetch，DOM 不会变），
+在用户的 Chrome 里看起来就是「一个卡死的标签页」，而漏掉释放**不会有任何报错**。
+脚本会把释放命令打到 stderr，看到就照着跑。
+
+`--session NAME` 可为并行任务指定独立会话名。默认会话名已经带每对话唯一后缀
+（`rankup-gt-trends-<后缀>`），但**同一个对话里 fan-out 的多个 sub agent 继承同一份
+环境变量、会算出同一个名字**——那种情况必须各自显式传 `--session`，否则它们共用
+一个标签页，第二个读到的是第一个打开的页面，且全程零报错。
 
 ### KD 难度估算
 

--- a/rankup/scripts/gt-browser.mjs
+++ b/rankup/scripts/gt-browser.mjs
@@ -15,14 +15,32 @@
  * 选项：--geo CODE  --time 1m|3m|12m|5y|all|START:END  --top N  --raw
  *       --session NAME  --keep-session
  *
+ * 会话默认跑完即释放。--keep-session 会保留标签页，脚本会把释放命令打到 stderr——
+ * 忘了释放不会报错，只会在用户的 Chrome 里留下一个看起来卡死的标签页。
+ *
  * 依赖：opencli（浏览器桥要绿，先跑 opencli doctor）
  */
 
 import { execFileSync } from "node:child_process";
 
-// 会话名必须是描述性常量。Bash tool 每次调用都是新进程，$$ / process.pid
-// 在那里会每次生成新名字，导致上一条命令开的标签页被遗弃。
-const DEFAULT_SESSION = "rankup-gt-trends";
+// 会话名要同时满足两件事，缺一个都会静默出错：
+//   · 描述性——名字是唯一存在的标识，得能回答「这是谁的标签页」；
+//   · 唯一性——一个字面常量会让两个并行任务（或两个 sub agent）算出同一个名字，
+//     于是共用同一个标签页，第二个读到的是第一个打开的页面，**全程零报错**。
+// 后缀按「每个对话」派生：CLAUDE_CODE_SESSION_ID 才是真正会并发的那个单位；
+// HOST_SESSION_ID 是同一个桌面 app 里所有对话共享的，只能兜底。
+// 不要在 Bash tool 里用 $$ 自己拼——那里每次调用都是新进程，PID 每次都变，
+// 于是每条命令都开一个新标签页，上一条打开的被遗弃。
+// 并行 sub agent 继承同一份环境变量，必须各自显式传 --session。
+function defaultSession() {
+  const suffix = (
+    process.env.OPENCLI_SESSION_SUFFIX ||
+    process.env.CLAUDE_CODE_SESSION_ID ||
+    process.env.CLAUDE_CODE_HOST_SESSION_ID ||
+    String(process.ppid)
+  ).replace(/[^a-zA-Z0-9]/g, "").slice(0, 12) || "local";
+  return `rankup-gt-trends-${suffix}`;
+}
 const EXPLORE_URL = "https://trends.google.com/trends/explore?hl=en-US";
 const OPENCLI = process.env.GT_OPENCLI ?? "opencli";
 // How long to let the Trends bundle boot before querying its APIs from the page.
@@ -241,11 +259,20 @@ function fetchTrends(keywords, opts, { resolution } = {}) {
   if (keywords.length > 5) die("Google Trends 一次最多对比 5 个关键词");
   const geo = opts.geo ?? "";
   const timeframe = toTimeframe(opts.time);
-  const session = opts.session ?? DEFAULT_SESSION;
+  const session = opts.session ?? defaultSession();
   try {
     return { data: runBatch(extractor({ keywords, geo, timeframe, resolution }), session), geo, timeframe };
   } finally {
-    if (!opts.keepSession) closeSession(session);
+    if (opts.keepSession) {
+      // 保留会话是合法用法（连续查多个词时省掉重开页面），但它留下的标签页
+      // 会一直停在空白的 explore 界面上——取数全在页面内 fetch，DOM 不会变，
+      // 在用户的 Chrome 里看起来就是「一个卡死的标签页」。忘了释放不会有任何
+      // 报错，所以这里必须把释放命令喊出来，别让它变成一个静默的遗留。
+      console.error(`[gt-browser] 会话 ${session} 已保留，用完请释放：` +
+        `\n  node gt-browser.mjs close --session ${session}`);
+    } else {
+      closeSession(session);
+    }
   }
 }
 
@@ -353,7 +380,7 @@ function cmdRelated(kws, opts) {
 
 function cmdClose(kws, opts) {
   if (kws.length) die("close 不需要关键词");
-  const session = opts.session ?? DEFAULT_SESSION;
+  const session = opts.session ?? defaultSession();
   closeSession(session);
   console.log(`已释放 Trends 会话：${session}`);
 }
@@ -374,7 +401,7 @@ function main() {
         "",
         "  --geo CODE   地区（留空=全球）   --time 7d|28d|30d|1m|3m|12m|5y|all|START:END",
         "  --top N      条数（默认 15）     --raw  compare 不做月度聚合",
-        "  --session NAME  会话名（默认 rankup-gt-trends）",
+        "  --session NAME  会话名（默认 rankup-gt-trends-<每对话唯一后缀>）",
         "  --keep-session  跑完保留会话，连续查询后用 close 释放",
       ].join("\n"),
     );

--- a/rankup/scripts/gt.py
+++ b/rankup/scripts/gt.py
@@ -16,8 +16,10 @@
   --region CODE  hot 的地区（默认 US；不支持 CN）
   --limit N      hot 显示条数（默认 20）
   --via ROUTE    取数路由：browser（默认）/ pytrends / auto
-  --session NAME  browser 会话名（默认 rankup-gt-trends）
+  --session NAME  browser 会话名（默认 rankup-gt-trends-<每对话唯一后缀>）
   --keep-session  browser 跑完保留会话，连续查询后用 close 释放
+                  （默认跑完即释放；保留时释放命令会打到 stderr——忘了释放不报错，
+                   只会在你的 Chrome 里留下一个停在 explore 页、看起来卡死的标签页）
 
 路由说明：
   browser  走 gt-browser.mjs：OpenCLI 驱动已登录 Chrome，在 trends.google.com

--- a/rankup/scripts/validate-rankup.mjs
+++ b/rankup/scripts/validate-rankup.mjs
@@ -9,7 +9,7 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 const skillRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const expectedVersion = "2.60.0";
+const expectedVersion = "2.60.1";
 const requiredReferences = [
   "checklists.md",
   "lifecycle.md",

--- a/rankup/skill.json
+++ b/rankup/skill.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
   "name": "rankup",
-  "version": "2.60.0",
-  "releasedAt": "2026-08-28T00:00:00.000Z",
+  "version": "2.60.1",
+  "releasedAt": "2026-08-28T10:30:00.000Z",
   "source": "yan-labs/yan-skills",
   "manifestUrl": "https://raw.githubusercontent.com/yan-labs/yan-skills/main/rankup/skill.json"
 }


### PR DESCRIPTION
## 问题

`gt-browser.mjs` 的默认会话名是字面常量 `rankup-gt-trends`。

- 两个并行任务、或同一对话里 fan-out 的两个 sub agent，会算出**同一个名字** → 共用同一个标签页 → 第二个读到的是第一个打开的页面。**全程零报错。**
- `--keep-session` 留下的标签页永远停在空白的 `trends.google.com/trends/explore` 上（取数全在页面内 `fetch`，DOM 不会变），在用户 Chrome 里看起来就是「一个卡死的标签页」，而漏掉释放没有任何信号。这条是真实发生过的：一次调研里它在用户浏览器里挂了约 20 分钟，用户以为脚本挂了。

原注释把「要描述性」当成了用字面常量的理由——描述性和唯一性是两个要求，缺一个都出错。

## 改动

- 会话名 = `rankup-gt-trends-<后缀>`，后缀按 `OPENCLI_SESSION_SUFFIX` → `CLAUDE_CODE_SESSION_ID` → `CLAUDE_CODE_HOST_SESSION_ID` → `ppid` 派生。`HOST_SESSION_ID` 只兜底：它是同一个桌面 app 里所有对话共享的，拿它当首选等于没修。
- `--keep-session` 仍是合法用法（连查多个词时省掉重开页面），但现在把释放命令打到 stderr。
- `references/trends.md`、`gt.py` 的帮助文案同步；补上「同一对话里的并行 sub agent 必须各自显式传 `--session`」这条——它们继承同一份环境变量，后缀会撞。

## 验证（2026-08-28，CLI 1.8.7 / 扩展 1.0.32，macOS Chrome）

| 路径 | 结果 |
|---|---|
| 默认 | 数据正常返回，跑完 `sessions` 里没有残留 |
| `--keep-session` | 打印 `node gt-browser.mjs close --session rankup-gt-trends-<后缀>`，`sessions` 里会话确实还在 |
| 照打印的命令 close | 归零 |

版本 2.60.0 → 2.60.1（SKILL.md / skill.json / validate-rankup.mjs 预期 / README 四处同步），`validate-rankup.mjs` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)